### PR TITLE
Fix item placeholder

### DIFF
--- a/src/main/java/net/draycia/carbon/listeners/ItemLinkHandler.java
+++ b/src/main/java/net/draycia/carbon/listeners/ItemLinkHandler.java
@@ -9,23 +9,21 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Pattern;
 
 public class ItemLinkHandler implements Listener {
 
+    @NotNull
     private final CarbonChat carbonChat;
 
-    public ItemLinkHandler(CarbonChat carbonChat) {
+    public ItemLinkHandler(@NotNull CarbonChat carbonChat) {
         this.carbonChat = carbonChat;
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onItemLink(ChatComponentEvent event) {
-        if (true) {
-            return;
-        }
-
         // Handle item linking placeholders
         if (event.getSender().isOnline()) {
             Player player = event.getSender().asPlayer();
@@ -44,7 +42,7 @@ public class ItemLinkHandler implements Listener {
                 String patternContent = pattern.toString().replace("\\Q", "").replace("\\E", "");
 
                 if (event.getOriginalMessage().contains(patternContent)) {
-                    TextComponent component = (TextComponent)event.getComponent().replaceFirstText(pattern, (input) -> {
+                    TextComponent component = (TextComponent) event.getComponent().replaceFirstText(pattern, (input) -> {
                         return TextComponent.builder().append(itemComponent);
                     });
 

--- a/src/main/java/net/draycia/carbon/util/CarbonUtils.java
+++ b/src/main/java/net/draycia/carbon/util/CarbonUtils.java
@@ -56,17 +56,19 @@ public final class CarbonUtils {
             HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_ITEM, content);
 
             ComponentBuilder component = new ComponentBuilder();
+            component.event(event); // Let this be inherited by all coming components.
             component.color(ChatColor.WHITE).append("[");
 
             if (itemStack.getItemMeta().hasDisplayName()) {
                 component.append(TextComponent.fromLegacyText(itemStack.getItemMeta().getDisplayName()));
             } else {
-                component.append(new TranslatableComponent(itemStack.getItemMeta().getLocalizedName()));
+                String name = itemStack.getItemMeta().hasDisplayName()
+                        ? itemStack.getItemMeta().getDisplayName()
+                        : "item.minecraft." + itemStack.getType().name().toLowerCase(); // As of 1.13, Material is 1:1 with MC's names
+                component.append(new TranslatableComponent(name));
             }
 
             component.color(ChatColor.WHITE).append("]");
-
-            component.event(event);
 
             return BungeeCordComponentSerializer.get().deserialize(component.create());
         } catch (NoSuchMethodError ignored) {}


### PR DESCRIPTION
The `[item]` (or whatever else is configured) now works.

This probably won't work correctly on 1.12 and below. As I do not care a single bit for outdated versions, that's not an issue I'll look into.