### PR TITLE
Fix quick-prefix routing and thread safety / Folia compat for Paper 26.1.2+

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
@@ -23,11 +23,11 @@ import com.google.inject.Inject;
 import io.leangen.geantyref.TypeToken;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import net.draycia.carbon.api.CarbonServer;
 import net.draycia.carbon.api.channels.ChannelPermissions;
 import net.draycia.carbon.api.channels.ChatChannel;
@@ -113,7 +113,7 @@ public class ConfigChatChannel implements ChatChannel {
         because they're out of range from the radius.""")
     private boolean emptyRadiusRecipientsMessage = true;
 
-    private Map<UUID, Long> cooldowns = new HashMap<>();
+    private Map<UUID, Long> cooldowns = new ConcurrentHashMap<>();
 
     private long cooldown = -1;
 

--- a/common/src/main/java/net/draycia/carbon/common/event/events/CarbonEarlyChatEvent.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/CarbonEarlyChatEvent.java
@@ -19,6 +19,7 @@
  */
 package net.draycia.carbon.common.event.events;
 
+import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.Cancellable;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
@@ -27,11 +28,13 @@ public class CarbonEarlyChatEvent implements CarbonEvent, Cancellable {
 
     private final CarbonPlayer sender;
     private String message;
+    private final ChatChannel channel;
     private boolean cancelled = false;
 
-    public CarbonEarlyChatEvent(final CarbonPlayer sender, final String message) {
+    public CarbonEarlyChatEvent(final CarbonPlayer sender, final String message, final ChatChannel channel) {
         this.sender = sender;
         this.message = message;
+        this.channel = channel;
     }
 
     public CarbonPlayer sender() {
@@ -44,6 +47,10 @@ public class CarbonEarlyChatEvent implements CarbonEvent, Cancellable {
 
     public void message(final String message) {
         this.message = message;
+    }
+
+    public ChatChannel channel() {
+        return this.channel;
     }
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -113,7 +113,7 @@ public abstract class ChatListenerInternal {
         final String plainContent = PlainTextComponentSerializer.plainText().serialize(channelMessage.message());
         final String content = this.configManager.primaryConfig().applyChatPlaceholders(plainContent);
 
-        final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content);
+        final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content, channel);
         this.carbonEventHandler.emit(earlyChatEvent);
 
         return earlyChatEvent;

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
@@ -83,7 +83,7 @@ public class FabricChatHandler extends ChatListenerInternal implements ServerMes
         }
 
         final @Nullable Component message = this.parseTags(sender, earlyChatEvent.message());
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, audiences.asAdventure(chatMessage));
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, audiences.asAdventure(chatMessage), earlyChatEvent.channel());
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return false;

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
@@ -125,10 +125,16 @@ public final class CarbonChatPaper extends CarbonChatInternal {
             } catch (final IOException e) {
                 this.logger().error("Smoke test: Failed to create file.", e);
             }
-            this.plugin.getServer().getScheduler().runTaskLater(this.plugin, () -> {
+            final Runnable shutdownTask = () -> {
                 this.logger().info("Smoke test: Shutting down server.");
                 Bukkit.getServer().shutdown();
-            }, 20L);
+            };
+            try {
+                Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+                this.plugin.getServer().getGlobalRegionScheduler().runDelayed(this.plugin, $ -> shutdownTask.run(), 20L);
+            } catch (final ClassNotFoundException e) {
+                this.plugin.getServer().getScheduler().runTaskLater(this.plugin, shutdownTask, 20L);
+            }
         }
     }
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
@@ -97,7 +97,15 @@ public class McmmoPartyChannel extends ConfigChatChannel {
     }
 
     private @Nullable Party party(final CarbonPlayer player) {
-        return com.gmail.nossr50.util.player.UserManager.getPlayer(Bukkit.getPlayer(player.uuid())).getParty();
+        final @Nullable Player bukkit = Bukkit.getPlayer(player.uuid());
+        if (bukkit == null) {
+            return null;
+        }
+        final var mcmmoPlayer = com.gmail.nossr50.util.player.UserManager.getPlayer(bukkit);
+        if (mcmmoPlayer == null) {
+            return null;
+        }
+        return mcmmoPlayer.getParty();
     }
 
     @Override

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -118,7 +118,8 @@ public final class PaperChatListener extends ChatListenerInternal implements Lis
             final Audience recipientViewer;
 
             if (recipientUUID.isPresent()) {
-                recipientViewer = this.carbonChat.userManager().user(recipientUUID.get()).join();
+                final @Nullable CarbonPlayer cached = this.carbonChat.userManager().user(recipientUUID.get()).getNow(null);
+                recipientViewer = cached != null ? cached : recipient;
             } else {
                 recipientViewer = recipient;
             }

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -93,7 +93,13 @@ public final class PaperChatListener extends ChatListenerInternal implements Lis
             return;
         }
 
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, event.message(), event.signedMessage());
+        // Resolve the channel from the player's raw typed text (signed message body),
+        // because event.originalMessage() in newer Paper reflects the decorator's result, not the original input.
+        final Component rawMessage = event.signedMessage() != null
+            ? Component.text(event.signedMessage().message())
+            : event.originalMessage();
+        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(rawMessage);
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, event.message(), event.signedMessage(), channelMessage.channel());
 
         if (chatEvent == null || chatEvent.cancelled()) {
             event.setCancelled(true);

--- a/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
@@ -78,34 +78,35 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
 
     @Override
     public double distanceSquaredFrom(final CarbonPlayer other) {
-        if (this.player().isEmpty()) {
-            return -1;
-        }
-
-        final @Nullable Player player = this.player().orElse(null);
+        final @Nullable Player player = Bukkit.getPlayer(this.uuid());
         final @Nullable Player otherPlayer = Bukkit.getPlayer(other.uuid());
 
         if (player == null || otherPlayer == null) {
             return -1;
         }
 
-        return player.getLocation().distanceSquared(otherPlayer.getLocation());
+        try {
+            return player.getLocation().distanceSquared(otherPlayer.getLocation());
+        } catch (final Exception e) {
+            // On Folia, getLocation() throws if called from outside the player's region
+            return -1;
+        }
     }
 
     @Override
     public boolean sameWorldAs(final CarbonPlayer other) {
-        if (this.player().isEmpty()) {
-            return false;
-        }
-
-        final Optional<Player> player = this.player();
+        final @Nullable Player player = Bukkit.getPlayer(this.uuid());
         final @Nullable Player otherPlayer = Bukkit.getPlayer(other.uuid());
 
-        if (player.isEmpty() || otherPlayer == null) {
+        if (player == null || otherPlayer == null) {
             return false;
         }
 
-        return player.get().getWorld().equals(otherPlayer.getWorld());
+        try {
+            return player.getWorld().equals(otherPlayer.getWorld());
+        } catch (final Exception e) {
+            return false;
+        }
     }
 
     @Override
@@ -183,9 +184,7 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
 
     @Override
     public void sendMessageAsPlayer(final String message) {
-        // TODO: ensure method is not executed from main thread
-        // bukkit doesn't like that
-        this.player().ifPresent(player -> player.chat(message));
+        this.player().ifPresent(player -> this.carbonPlayerCommon.schedule(() -> player.chat(message)));
     }
 
     @Override

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -124,7 +124,7 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
             return;
         }
 
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, null);
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, null, earlyChatEvent.channel());
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return;


### PR DESCRIPTION
## Summary

### Quick-prefix channel routing fix (Paper 26.1.2+)

- Quick-prefix routing (e.g. `!hello` to a global channel configured with `quick-prefix="!"`) silently broke on Paper 26.1.2 — messages with the prefix were being delivered to the player's selected channel with the prefix stripped, instead of being routed to the prefix's channel.
- Root cause: Paper 26.1.2 changed `AsyncChatEvent.originalMessage()` to return the result of the last `AsyncChatDecorateEvent` iteration, rather than the player's truly typed input. Carbon's pre/post split (introduced in #747) strips the prefix in the decorator and then re-resolves the channel from `originalMessage()` in the chat event — on newer Paper that re-resolution sees the already-stripped text and falls back to the default channel.
- Fix: use `event.signedMessage().message()` (the immutable signed string) as the source of truth for the raw typed text in `PaperChatListener`, and carry the channel resolved during the early event through `CarbonEarlyChatEvent` for the Fabric and Velocity listeners that don't have a separate chat-event stage.

### Thread safety and Folia 26.1.2 compatibility fixes

- **Thread-safe channel cooldowns**: Replace `HashMap` with `ConcurrentHashMap` in `ConfigChatChannel` to prevent data races when chat events fire from multiple Folia region threads concurrently.
- **Folia region-safety in `CarbonPlayerPaper`**: Wrap `getLocation()`/`getWorld()` calls in try-catch since they throw when called from outside the owning region on Folia. Route `sendMessageAsPlayer` through `PlatformScheduler` for proper region-aware execution.
- **NPE fix in `McmmoPartyChannel`**: Add null checks for `Bukkit.getPlayer()` and mcMMO `UserManager.getPlayer()` return values.
- **Non-blocking chat renderer**: Replace `userManager.user().join()` with `.getNow(null)` in the per-recipient renderer to avoid stalling region tick threads (the user is always cached at render time since they were just resolved as a recipient).
- **Folia-compatible smoke test**: Use `getGlobalRegionScheduler()` instead of the legacy `BukkitScheduler` when running on Folia.

## Test plan

- [ ] Configure two channels (e.g. `local` as default and `global` with `quick-prefix="!"`) on Paper 26.1.2+
- [ ] Plain message goes to `local`
- [ ] `!message` goes to `global` with the `!` stripped
- [ ] `!!message` goes to `global` with one `!` retained in the body
- [ ] Bare `!` is handled gracefully (no NPE, no misrouting)
- [ ] Regression-check on Paper 1.21.11 (legacy `originalMessage` semantics)
- [ ] Verify chat cooldowns work correctly under concurrent load
- [ ] Verify radius-based channels gracefully degrade on Folia (players in different regions see fallback behavior instead of exceptions)
- [ ] Verify mcMMO party channel doesn't NPE when a player is offline or mcMMO data isn't loaded
- [ ] Verify chat rendering still works correctly with `.getNow(null)` (recipient should always be cached)
- [ ] Smoke-check Fabric and Velocity chat paths still route as expected
- [ ] Verify smoke test passes on both Paper and Folia (`-PsmokeTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)