### PR TITLE
Add config option to only allow formatting changes in nicknames

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -128,6 +128,11 @@ public final class NicknameCommand extends CarbonCommand {
 
         final String plainNick = PlainTextComponentSerializer.plainText().serialize(parsedNick);
 
+        if (!sender.hasPermission("carbon.nickname.changename") && !this.config.primaryConfig().nickname().allowNameChanges() && !target.username().equals(plainNick)) {
+            this.carbonMessages.nicknameErrorNameChange(sender, parsedNick);
+            return;
+        }
+
         // If the nickname is caught in the character limit, return without setting a nickname.
         final int minLength = this.config.primaryConfig().nickname().minLength();
         final int maxLength = this.config.primaryConfig().nickname().maxLength();

--- a/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
@@ -276,6 +276,9 @@ public class PrimaryConfig {
         @Comment("Whether to skip applying 'format' when a nickname matches a players username, only differing in decoration.")
         public boolean skipFormatWhenNameMatches = true;
 
+        @Comment("Whether to allow players to change their name, or only change the formatting while keeping their real username.")
+        public boolean allowNameChanges = true;
+
         public boolean useCarbonNicknames() {
             return this.useCarbonNicknames;
         }
@@ -298,6 +301,10 @@ public class PrimaryConfig {
 
         public int maxLength() {
             return this.maxLength;
+        }
+
+        public boolean allowNameChanges() {
+            return this.allowNameChanges;
         }
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessages.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessages.java
@@ -245,6 +245,9 @@ public interface CarbonMessages {
     @Message("nickname.error.blacklist")
     void nicknameErrorBlackList(final Audience audience, final Component nickname);
 
+    @Message("nickname.error.namechange")
+    void nicknameErrorNameChange(final Audience audience, final Component nickname);
+
     @Message("nickname.error.filter")
     void nicknameErrorFilter(final Audience audience, final Component nickname);
 

--- a/common/src/main/resources/locale/messages-en_US.properties
+++ b/common/src/main/resources/locale/messages-en_US.properties
@@ -140,6 +140,7 @@ nickname.show.others.unset=<target><red> does not have a nickname set
 nickname.show.others=<target><green>'s nickname is </green><nickname>
 nickname.show.unset=<red>You do not have a nickname set
 nickname.show=<green>Your nickname is </green><nickname>
+nickname.error.namechange=<red>Nickname "<nickname>" does not match your real username. Please make sure to only change the formatting.
 nickname.error.character_limit=<red>Nickname "<nickname>" has exceeded the character limit. Must be set to <min_length>~<max_length> characters.
 nickname.error.blacklist=<red>Nickname "<nickname>" is not allowed. Please choose another name.
 nickname.error.filter=<red>Nicknames must be alphanumeric!


### PR DESCRIPTION
This PR adds a new configuration option to the nickname settings `allowNameChanges` (default true) that functions similarly to the Essentials `essentials.nick.changecolors` permission node. With this setting enabled, unless the user has the permission `carbon.nickname.changename` their nickname must only contain formatting changes and equal their real username when plain serialized.