### PR TITLE
Add config option to disable updates to player's display name

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
@@ -256,6 +256,9 @@ public class PrimaryConfig {
         @Comment("Whether Carbon's nickname management should be used. Disable this if you wish to have another plugin manage nicknames.")
         private boolean useCarbonNicknames = true;
 
+        @Comment("Paper only. Updates the player's display name to match their nickname.")
+        private boolean updateDisplayName = true;
+
         @Comment("Paper only. Updates the player's display name in the tab list to match their nickname.")
         private boolean updateTabList = true;
 
@@ -278,6 +281,10 @@ public class PrimaryConfig {
 
         public boolean useCarbonNicknames() {
             return this.useCarbonNicknames;
+        }
+
+        public boolean updateDisplayName() {
+            return this.updateDisplayName;
         }
 
         public boolean updateTabList() {

--- a/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
@@ -176,9 +176,8 @@ public abstract class WrappedCarbonPlayer implements CarbonPlayer {
     @Override
     public Component displayName() {
         final @Nullable Component nick = this.nickname();
-        if (nick != null) {
-            final PrimaryConfig.NicknameSettings nicknames = this.carbonPlayerCommon.configManager().primaryConfig().nickname();
-
+        final PrimaryConfig.NicknameSettings nicknames = this.carbonPlayerCommon.configManager().primaryConfig().nickname();
+        if (nicknames.updateDisplayName() && nick != null) {
             if (nicknames.skipFormatWhenNameMatches) {
                 final String plainNick = PlainTextComponentSerializer.plainText().serialize(nick);
                 if (plainNick.equals(this.username())) {

--- a/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
@@ -117,7 +117,9 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
 
     private Consumer<Player> applyDisplayNameToBukkit(final @Nullable Component displayName) {
         return bukkit -> this.carbonPlayerCommon.schedule(() -> {
-            bukkit.displayName(displayName);
+            if (this.carbonPlayerCommon.configManager().primaryConfig().nickname().updateDisplayName()) {
+                bukkit.displayName(displayName);
+            }
 
             if (this.carbonPlayerCommon.configManager().primaryConfig().nickname().updateTabList()) {
                 bukkit.playerListName(displayName);


### PR DESCRIPTION
This PR adds a config option that stops Carbon from doing the following two things:
- On paper, change the platform display name to be the player's nickname
- In common, change the carbon player display name to always be the platform display name, even if nicked.

In practice, what I want to achieve with this PR is to make it possible to delegate management of the player's display name to some other plugin, which can then, for example, use the Carbon API or the Carbon-provided MiniPlaceholder placeholders to generate a display name from the player's nickname and consider additional formatting.

In my case, I want prefixes and suffixes to be included in the display name for compatibility reasons.