### PR TITLE
fix: bump update cloud-minecraft to 2.0.0-beta.17 for Paper 26.2 compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ resource-factory = "1.3.1"
 
 adventure = "4.18.0"
 cloud = "2.0.0"
-cloudMinecraft = "2.0.0-beta.15"
+cloudMinecraft = "2.0.0-beta.17"
 cloudModded = "2.0.0-beta.15"
 cloudSponge = "2.0.0-SNAPSHOT"
 configurate = "4.2.0"


### PR DESCRIPTION
Needed because there was a breaking ItemStack Change and Carbon refuses to start on that version. 