### PR TITLE
Fixing the work of quickPrefix

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -39,6 +39,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentIteratorType;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -65,7 +66,18 @@ public abstract class ChatListenerInternal {
         final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(originalMessage);
         final ChatChannel channel = channelMessage.channel();
 
-        return this.prepareAndEmitChatEvent(sender, channelMessage.message(), signedMessage, channel);
+        Component message = originalMessage;
+
+        final String prefix = channel.quickPrefix();
+        if (prefix != null) {
+            message = originalMessage.replaceText(TextReplacementConfig.builder()
+                .once()
+                .matchLiteral(prefix)
+                .replacement(Component.empty())
+                .build());
+        }
+
+        return this.prepareAndEmitChatEvent(sender, message, signedMessage, channel);
     }
 
     protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component message, final @Nullable SignedMessage signedMessage, final ChatChannel channel) {

--- a/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
@@ -39,7 +39,6 @@ import net.draycia.carbon.common.messages.TagPermissions;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -236,9 +235,6 @@ public abstract class WrappedCarbonPlayer implements CarbonPlayer {
     @Override
     public ChannelMessage channelForMessage(final Component message) {
         final String text = PlainTextComponentSerializer.plainText().serialize(message);
-        Component formattedMessage = message;
-
-        ChatChannel channel = requireNonNullElse(this.selectedChannel(), this.carbonPlayerCommon.channelRegistry().defaultChannel());
 
         for (final Key channelKey : this.carbonPlayerCommon.channelRegistry().keys()) {
             final ChatChannel chatChannel = this.carbonPlayerCommon.channelRegistry().channelOrThrow(channelKey);
@@ -249,17 +245,16 @@ public abstract class WrappedCarbonPlayer implements CarbonPlayer {
             }
 
             if (text.startsWith(prefix) && chatChannel.permissions().speechPermitted(this).permitted()) {
-                channel = chatChannel;
-                formattedMessage = formattedMessage.replaceText(TextReplacementConfig.builder()
-                    .once()
-                    .matchLiteral(channel.quickPrefix())
-                    .replacement(Component.empty())
-                    .build());
-                break;
+                return new ChannelMessage(message, chatChannel);
             }
         }
 
-        return new ChannelMessage(formattedMessage, channel);
+        return new ChannelMessage(message,
+            requireNonNullElse(
+                this.selectedChannel(),
+                this.carbonPlayerCommon.channelRegistry().defaultChannel()
+            )
+        );
     }
 
     @Override


### PR DESCRIPTION
The logic for replacing `quickPrefix` has been moved from `channelForMessage` to `ChatListenerInternal` to prevent the prefix from being replaced twice when a channel is received in `onPaperChatDecorate`.

Why does `channelForMessage` modify the message and return a `ChannelMessage` at all, rather than just a `ChatChannel`? I couldn’t think of an elegant way to apply this to the general API, so I left it as it is for a quick fix.