### PR TITLE
🐛 Preserve original message for post-phase channel resolution

### DIFF
--- a/api/src/main/java/net/draycia/carbon/api/users/CarbonPlayer.java
+++ b/api/src/main/java/net/draycia/carbon/api/users/CarbonPlayer.java
@@ -163,13 +163,22 @@ public interface CarbonPlayer extends Audience, Identified {
     void selectedChannel(@Nullable ChatChannel chatChannel);
 
     /**
-     * Determines which channel the message should go to, and removes any channel prefixes from the message.
+     * Determines which channel the message should go to.
      *
-     * @param message the message to be sent
-     * @return the channel and message
+     * @param originalMessage the original, unmodified message
+     * @return the channel, null if the player is console
      * @since 3.0.0
      */
-    ChannelMessage channelForMessage(Component message);
+    @Nullable ChatChannel channelForMessage(String originalMessage);
+
+    /**
+     * Determines which channel the message should go to, and removes any channel prefixes from the message.
+     *
+     * @param message the component to be sent
+     * @return the channel and message, both is null if the player is console
+     * @since 3.0.0
+     */
+    ChannelMessage resolveChannelMessage(Component message);
 
     /**
      * A message and which channel it should be sent in.
@@ -178,7 +187,7 @@ public interface CarbonPlayer extends Audience, Identified {
      * @param channel The channel the message should be sent to
      * @since 3.0.0
      */
-    record ChannelMessage(Component message, ChatChannel channel) {}
+    record ChannelMessage(@Nullable Component message, @Nullable ChatChannel channel) {}
 
     /**
      * Checks if the player has the specified permission.

--- a/common/src/main/java/net/draycia/carbon/common/event/events/CarbonChatEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/CarbonChatEventImpl.java
@@ -55,8 +55,8 @@ public class CarbonChatEventImpl extends CancellableImpl implements CarbonChatEv
         final Component originalMessage,
         final List<? extends Audience> recipients,
         final List<KeyedRenderer> renderers,
-        final @Nullable ChatChannel chatChannel,
-        final @Nullable SignedMessage signedMessage
+        final ChatChannel chatChannel,
+        final SignedMessage signedMessage
     ) {
         this(sender, originalMessage, recipients, renderers, chatChannel, signedMessage, true);
     }

--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -22,6 +22,7 @@ package net.draycia.carbon.common.listeners;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import net.draycia.carbon.api.channels.ChannelPermissionResult;
 import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.CarbonEventHandler;
@@ -47,6 +48,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
 @DefaultQualifier(NonNull.class)
 public abstract class ChatListenerInternal {
 
+    private static final String CONSOLE_SENDER_PASSED_ERROR = "Channel resolution is not supported for console senders";
     private final ConfigManager configManager;
     private final CarbonMessages carbonMessages;
     private final CarbonEventHandler carbonEventHandler;
@@ -61,14 +63,13 @@ public abstract class ChatListenerInternal {
         this.carbonEventHandler = carbonEventHandler;
     }
 
-    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component originalMessage, final @Nullable SignedMessage signedMessage) {
-        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(originalMessage);
-        final ChatChannel channel = channelMessage.channel();
+    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component originalMessage, final SignedMessage signedMessage) {
+        final @Nullable ChatChannel channel = sender.channelForMessage(signedMessage.message());
 
-        return this.prepareAndEmitChatEvent(sender, channelMessage.message(), signedMessage, channel);
+        return this.prepareAndEmitChatEvent(sender, originalMessage, signedMessage, Objects.requireNonNull(channel, CONSOLE_SENDER_PASSED_ERROR));
     }
 
-    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component message, final @Nullable SignedMessage signedMessage, final ChatChannel channel) {
+    protected @Nullable CarbonChatEventImpl prepareAndEmitChatEvent(final CarbonPlayer sender, final Component message, final SignedMessage signedMessage, final ChatChannel channel) {
         if (!sender.hasPermission("carbon.cooldown.exempt") && channel.cooldown() > 0) {
             final long currentMillis = System.currentTimeMillis();
             final long expiresAt = channel.playerCooldown(sender);
@@ -101,16 +102,19 @@ public abstract class ChatListenerInternal {
     }
 
     protected @Nullable CarbonEarlyChatEvent prepareAndEmitPreChatEvent(final CarbonPlayer sender, final Component originalMessage) {
-        final CarbonPlayer.ChannelMessage channelMessage = sender.channelForMessage(originalMessage);
-        final ChatChannel channel = channelMessage.channel();
+        final CarbonPlayer.ChannelMessage channelMessage = sender.resolveChannelMessage(originalMessage);
 
+        return prepareAndEmitPreChatEvent(sender, Objects.requireNonNull(channelMessage.message(), CONSOLE_SENDER_PASSED_ERROR), Objects.requireNonNull(channelMessage.channel(), CONSOLE_SENDER_PASSED_ERROR));
+    }
+
+    protected @Nullable CarbonEarlyChatEvent prepareAndEmitPreChatEvent(final CarbonPlayer sender, final Component message, final ChatChannel channel) {
         final ChannelPermissionResult permitted = channel.permissions().speechPermitted(sender);
         if (!permitted.permitted()) {
             sender.sendMessage(permitted.reason());
             return null;
         }
 
-        final String plainContent = PlainTextComponentSerializer.plainText().serialize(channelMessage.message());
+        final String plainContent = PlainTextComponentSerializer.plainText().serialize(message);
         final String content = this.configManager.primaryConfig().applyChatPlaceholders(plainContent);
 
         final CarbonEarlyChatEvent earlyChatEvent = new CarbonEarlyChatEvent(sender, content);

--- a/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
@@ -439,7 +439,12 @@ public class CarbonPlayerCommon implements CarbonPlayer, ForwardingAudience.Sing
     }
 
     @Override
-    public ChannelMessage channelForMessage(final Component message) {
+    public ChatChannel channelForMessage(final String originalMessage) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ChannelMessage resolveChannelMessage(final Component message) {
         throw new UnsupportedOperationException();
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
@@ -279,7 +279,12 @@ public class ConsoleCarbonPlayer implements CarbonPlayer, ForwardingAudience.Sin
     }
 
     @Override
-    public ChannelMessage channelForMessage(final Component message) {
+    public @Nullable ChatChannel channelForMessage(final String originalMessage) {
+        return null;
+    }
+
+    @Override
+    public ChannelMessage resolveChannelMessage(final Component message) {
         return new ChannelMessage(message, null);
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -50,8 +51,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jetbrains.annotations.NotNull;
-
-import static java.util.Objects.requireNonNullElse;
 
 @DefaultQualifier(NonNull.class)
 public abstract class WrappedCarbonPlayer implements CarbonPlayer {
@@ -234,32 +233,60 @@ public abstract class WrappedCarbonPlayer implements CarbonPlayer {
     }
 
     @Override
-    public ChannelMessage channelForMessage(final Component message) {
-        final String text = PlainTextComponentSerializer.plainText().serialize(message);
-        Component formattedMessage = message;
+    public ChatChannel channelForMessage(final String originalMessage) {
+        return this.resolveChannel(originalMessage).channel();
+    }
 
-        ChatChannel channel = requireNonNullElse(this.selectedChannel(), this.carbonPlayerCommon.channelRegistry().defaultChannel());
+    @Override
+    public ChannelMessage resolveChannelMessage(
+        final Component message
+    ) {
+        final String text = PlainTextComponentSerializer.plainText().serialize(message);
+        final ChannelResolution resolution = this.resolveChannel(text);
+
+        if (!resolution.matchedPrefix()) {
+            return new ChannelMessage(message, resolution.channel());
+        }
+
+        final String prefix = Objects.requireNonNull(resolution.channel().quickPrefix());
+
+        final Component formattedMessage = message.replaceText(
+            TextReplacementConfig.builder()
+                .once()
+                .matchLiteral(prefix)
+                .replacement(Component.empty())
+                .build()
+        );
+
+        return new ChannelMessage(formattedMessage, resolution.channel());
+    }
+
+    private ChannelResolution resolveChannel(final String originalMessage) {
+        final ChatChannel fallbackChannel = Objects.requireNonNullElse(
+            this.selectedChannel(),
+            this.carbonPlayerCommon.channelRegistry().defaultChannel()
+        );
 
         for (final Key channelKey : this.carbonPlayerCommon.channelRegistry().keys()) {
-            final ChatChannel chatChannel = this.carbonPlayerCommon.channelRegistry().channelOrThrow(channelKey);
+            final ChatChannel chatChannel =
+                this.carbonPlayerCommon.channelRegistry().channelOrThrow(channelKey);
+
             final @Nullable String prefix = chatChannel.quickPrefix();
 
-            if (prefix == null) {
-                continue;
-            }
-
-            if (text.startsWith(prefix) && chatChannel.permissions().speechPermitted(this).permitted()) {
-                channel = chatChannel;
-                formattedMessage = formattedMessage.replaceText(TextReplacementConfig.builder()
-                    .once()
-                    .matchLiteral(channel.quickPrefix())
-                    .replacement(Component.empty())
-                    .build());
-                break;
+            if (prefix != null
+                && originalMessage.startsWith(prefix)
+                && chatChannel.permissions().speechPermitted(this).permitted()) {
+                return new ChannelResolution(chatChannel, true);
             }
         }
 
-        return new ChannelMessage(formattedMessage, channel);
+        return new ChannelResolution(fallbackChannel, false);
+    }
+
+    private record ChannelResolution(
+        ChatChannel channel,
+        boolean matchedPrefix
+    ) {
     }
 
     @Override

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -40,6 +40,7 @@ import net.draycia.carbon.common.listeners.ChatListenerInternal;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.velocity.CarbonVelocityBootstrap;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -124,7 +125,7 @@ public final class VelocityChatListener extends ChatListenerInternal implements 
             return;
         }
 
-        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, null);
+        final @Nullable CarbonChatEventImpl chatEvent = this.prepareAndEmitChatEvent(sender, message, SignedMessage.system(event.getMessage(), message));
 
         if (chatEvent == null || chatEvent.cancelled()) {
             return;


### PR DESCRIPTION
Since #747, quick-prefix handling was completely broken.

The root cause was that the message modified during the pre phase was passed to `channelForMessage` again during the post phase, causing channel resolution to run against an already transformed message.

This commit uses the player's original message from `SignedMessage#message` during the post event. According to guidance from the Paper Discord, this value should be used when the original message is needed before any transformations are applied.

To provide consistent behavior on Velocity, we now construct our own `SignedMessage`. This appeared to be the cleanest way to preserve the original message across platforms.

Channel resolution and message transformation have also been split into separate methods. Message transformation is only required during the pre phase, where the quick prefix must be detected and removed.

The implementation follows the existing structure while introducing as little additional overhead as possible.

Fixes #771.

This PR was created because the existing alternatives either contain significant flaws or introduce broader changes than necessary.

---

Supersedes #816 and #761 partly. Inspired by #775 and supersedes it partly.