### PR TITLE
Make sender nullable to handle non-player audiences gracefully.

### DIFF
--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
@@ -86,12 +86,7 @@ public class PaperMessageRenderer extends CarbonMessageRenderer {
             return this.miniMessage.deserialize(placeholderResolvedMessage, tagResolver.build());
         }
 
-        // We can't/shouldn't resolve placeholders for non-players
-        if (sender instanceof ConsoleCarbonPlayer) {
-            return this.miniMessage.deserialize(placeholderResolvedMessage, tagResolver.build());
-        }
-
-        final Player senderBukkitPlayer = requireNonNull(Bukkit.getPlayer(sender.uuid()));
+        final @Nullable Player senderBukkitPlayer = findBukkitPlayer(sender);
 
         final MiniPlaceholdersIntegration.@Nullable Config miniplaceholdersConfig = MiniPlaceholdersUtil.miniPlaceholdersLoaded()
             ? this.configManager.primaryConfig().integrations().config(MiniPlaceholdersIntegration.configMeta())
@@ -127,6 +122,13 @@ public class PaperMessageRenderer extends CarbonMessageRenderer {
         }
 
         return this.miniMessage.deserialize(placeholderResolvedMessage, MiniPlaceholdersUtil.wrapAudiences(miniplaceholdersConfig, recipientBukkitPlayer, senderBukkitPlayer), tagResolver.build());
+    }
+
+    private static @Nullable Player findBukkitPlayer(final CarbonPlayer sender) {
+        if (sender instanceof ConsoleCarbonPlayer) {
+            return null;
+        }
+        return requireNonNull(Bukkit.getPlayer(sender.uuid()));
     }
 
     private boolean hasPlaceholderAPI() {

--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
@@ -94,7 +94,7 @@ public final class PlaceholderAPIMiniMessageParser {
 
     private Component parse(
         final @Nullable Audience recipient,
-        final Audience sender,
+        final @Nullable Audience sender,
         final Pattern pattern,
         final UnaryOperator<String> placeholderResolver,
         final String input,
@@ -121,6 +121,10 @@ public final class PlaceholderAPIMiniMessageParser {
         }
 
         matcher.appendTail(builder);
+
+        if (sender == null) {
+            return this.miniMessage.deserialize(builder.toString(), tagResolver.build());
+        }
 
         return this.miniMessage.deserialize(builder.toString(), MiniPlaceholdersUtil.wrapAudiences(miniplaceholdersConfig, recipient, sender), tagResolver.build());
     }


### PR DESCRIPTION
With these changes' placeholder in formats coming from console are now supported. We might want a better way for setting a Console Prefix, but you can now do a thing like ```%changeoutput_equals_input:{luckperms_prefix}_matcher:_ifmatch:<red>Console</red>_else:{luckperms_prefix}%``` in the format, and it's resolved correctly.

Requested/asked on Discord.