### PR TITLE
fabric: ⬆️ Update to Minecraft 26.1.2

### DIFF
--- a/build-logic/src/main/kotlin/carbon.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/carbon.base-conventions.gradle.kts
@@ -5,6 +5,70 @@ plugins {
   id("net.kyori.indra.licenser.spotless")
 }
 
+repositories {
+  mavenCentral {
+    mavenContent { releasesOnly() }
+  }
+  maven("https://repo.jpenilla.xyz/snapshots/") {
+    mavenContent {
+      snapshotsOnly()
+      includeModuleByRegex("de\\.hexaoxi", "messenger-.*")
+      includeModule("org.incendo", "cloud-sponge")
+      includeModule("com.seiama", "registry")
+    }
+  }
+  maven("https://central.sonatype.com/repository/maven-snapshots/") {
+    mavenContent { snapshotsOnly() }
+  }
+  // PaperMC
+  maven("https://repo.papermc.io/repository/maven-public/")
+  // Sponge API
+  maven("https://repo.spongepowered.org/repository/maven-public/")
+  // PlaceholderAPI
+  maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") {
+    content { includeGroup("me.clip") }
+  }
+  // EssentialsDiscord
+  maven("https://repo.essentialsx.net/releases/") {
+    mavenContent {
+      releasesOnly()
+      includeGroup("net.essentialsx")
+    }
+  }
+  maven("https://repo.essentialsx.net/snapshots/") {
+    mavenContent {
+      snapshotsOnly()
+      includeGroup("net.essentialsx")
+    }
+  }
+  // DiscordSRV
+  maven("https://nexus.scarsz.me/content/groups/public/") {
+    mavenContent {
+      includeGroup("com.discordsrv")
+    }
+  }
+  // Glare's repo for Towny
+  maven("https://repo.glaremasters.me/repository/towny/") {
+    content { includeGroup("com.palmergames.bukkit.towny") }
+  }
+  // FactionsUUID
+  maven("https://ci.ender.zone/plugin/repository/everything/") {
+    content { includeGroup("com.massivecraft") }
+  }
+  // mcMMO
+  maven("https://nexus.neetgames.com/repository/maven-releases/") {
+    content {
+      includeGroup("com.gmail.nossr50.mcMMO")
+    }
+  }
+  // Parties
+  maven("https://repo.alessiodp.com/releases/") {
+    content {
+      includeGroup("com.alessiodp.parties")
+    }
+  }
+}
+
 version = rootProject.version
 
 indra {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -5,7 +5,7 @@ import kotlin.io.path.invariantSeparatorsPathString
 
 plugins {
   id("carbon.shadow-platform")
-  id("quiet-fabric-loom")
+  alias(libs.plugins.loom)
   alias(libs.plugins.resource.factory.fabric.convention)
 }
 
@@ -17,10 +17,9 @@ configurations.implementation {
 
 dependencies {
   minecraft(libs.fabricMinecraft)
-  mappings(loom.officialMojangMappings())
-  modImplementation(libs.fabricLoader)
-  modImplementation(libs.fabricApi)
-  modRuntimeOnly(libs.fabricApiDeprecated) // LuckPerms needs to work at dev time
+  implementation(libs.fabricLoader)
+  implementation(libs.fabricApi)
+  runtimeOnly(libs.fabricApiDeprecated) // LuckPerms needs to work at dev time
 
   shade(projects.carbonchatCommon) {
     exclude("net.kyori", "adventure-api")
@@ -33,18 +32,18 @@ dependencies {
     exclude("io.leangen.geantyref")
   }
 
-  modImplementation(libs.cloudFabric) {
+  implementation(libs.cloudFabric) {
     exclude("net.fabricmc.fabric-api")
   }
   include(libs.cloudFabric)
   implementation(libs.cloudSigned)
   include(libs.cloudSigned)
-  modImplementation(libs.fabricPermissionsApi)
+  implementation(libs.fabricPermissionsApi)
   include(libs.fabricPermissionsApi)
 
-  modImplementation(libs.adventurePlatformFabric)
+  implementation(libs.adventurePlatformFabric)
 
-  modImplementation(libs.miniplaceholders)
+  implementation(libs.miniplaceholders)
 
   runtimeDownload(libs.mysql)
   include(libs.jarRelocator)
@@ -80,7 +79,7 @@ fabricModJson {
 }
 
 carbonPlatform {
-  productionJar = tasks.remapJar.flatMap { it.archiveFile }
+  productionJar = tasks.shadowJar.flatMap { it.archiveFile }
 }
 
 tasks {
@@ -118,4 +117,10 @@ publishMods.modrinth {
   modLoaders.addAll("fabric")
   requires("fabric-api")
   requires("adventure-platform-mod")
+}
+
+indra {
+  javaVersions {
+    target(25)
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ resource-factory-paper-convention = { id = "xyz.jpenilla.resource-factory-paper-
 resource-factory-bukkit-convention = { id = "xyz.jpenilla.resource-factory-bukkit-convention", version.ref = "resource-factory" }
 resource-factory-velocity-convention = { id = "xyz.jpenilla.resource-factory-velocity-convention", version.ref = "resource-factory" }
 resource-factory-fabric-convention = { id = "xyz.jpenilla.resource-factory-fabric-convention", version.ref = "resource-factory" }
+loom = { id = "xyz.jpenilla.quiet-fabric-loom", version.ref = "loom" }
 
 [versions]
 indra = "4.0.0"
@@ -21,7 +22,7 @@ resource-factory = "1.3.1"
 adventure = "4.18.0"
 cloud = "2.0.0"
 cloudMinecraft = "2.0.0-beta.17"
-cloudModded = "2.0.0-beta.15"
+cloudModded = "2.0.0-beta.16"
 cloudSponge = "2.0.0-SNAPSHOT"
 configurate = "4.2.0"
 checkerQual = "3.49.2"
@@ -35,11 +36,12 @@ registry = "1.0.0-SNAPSHOT"
 kyoriMoonshine = "2.0.4"
 guice = "7.0.0"
 velocityApi = "3.5.0-SNAPSHOT"
-minecraft = "1.21.11"
+minecraft = "26.1.2"
 fabricLoader = "0.19.3"
-fabricApi = "0.141.4+1.21.11"
-fabricPermissionsApi = "0.6.1"
-adventurePlatformFabric = "6.8.0"
+loom = "1.17-SNAPSHOT"
+fabricApi = "0.155.2+26.1.2"
+fabricPermissionsApi = "0.7.0"
+adventurePlatformFabric = "6.9.0"
 luckPermsApi = "5.5"
 essentialsx = "2.20.1"
 discordsrv = "1.30.5"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,72 +1,5 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-dependencyResolutionManagement {
-  repositories {
-    mavenCentral {
-      mavenContent { releasesOnly() }
-    }
-    maven("https://repo.jpenilla.xyz/snapshots/") {
-      mavenContent {
-        snapshotsOnly()
-        includeModuleByRegex("de\\.hexaoxi", "messenger-.*")
-        includeModule("org.incendo", "cloud-sponge")
-        includeModule("com.seiama", "registry")
-      }
-    }
-    maven("https://central.sonatype.com/repository/maven-snapshots/") {
-      mavenContent { snapshotsOnly() }
-    }
-    // PaperMC
-    maven("https://repo.papermc.io/repository/maven-public/")
-    // Sponge API
-    maven("https://repo.spongepowered.org/repository/maven-public/")
-    // PlaceholderAPI
-    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/") {
-      content { includeGroup("me.clip") }
-    }
-    // EssentialsDiscord
-    maven("https://repo.essentialsx.net/releases/") {
-      mavenContent {
-        releasesOnly()
-        includeGroup("net.essentialsx")
-      }
-    }
-    maven("https://repo.essentialsx.net/snapshots/") {
-      mavenContent {
-        snapshotsOnly()
-        includeGroup("net.essentialsx")
-      }
-    }
-    // DiscordSRV
-    maven("https://nexus.scarsz.me/content/groups/public/") {
-      mavenContent {
-        includeGroup("com.discordsrv")
-      }
-    }
-    // Glare's repo for Towny
-    maven("https://repo.glaremasters.me/repository/towny/") {
-      content { includeGroup("com.palmergames.bukkit.towny") }
-    }
-    // FactionsUUID
-    maven("https://ci.ender.zone/plugin/repository/everything/") {
-      content { includeGroup("com.massivecraft") }
-    }
-    // mcMMO
-    maven("https://nexus.neetgames.com/repository/maven-releases/") {
-      content {
-        includeGroup("com.gmail.nossr50.mcMMO")
-      }
-    }
-    // Parties
-    maven("https://repo.alessiodp.com/releases/") {
-      content {
-        includeGroup("com.alessiodp.parties")
-      }
-    }
-  }
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-}
-
 pluginManagement {
   repositories {
     gradlePluginPortal()
@@ -81,7 +14,6 @@ pluginManagement {
 
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-  id("quiet-fabric-loom") version "1.16-SNAPSHOT"
 }
 
 rootProject.name = "CarbonChat"


### PR DESCRIPTION
Moving the repositories to the build script was necessary to make compiling work again, because the new version of loom doesn't support settings.gradle.kts. Another upside is that we can now also use the version catalog for that. 