### PR TITLE
Revert Velocity console MiniPlaceholders special case

### DIFF
--- a/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
@@ -29,7 +29,6 @@ import net.draycia.carbon.common.integration.miniplaceholders.MiniPlaceholdersUt
 import net.draycia.carbon.common.messages.CarbonMessageRenderer;
 import net.draycia.carbon.common.messages.RenderForTagResolver;
 import net.draycia.carbon.common.messages.SourcedAudience;
-import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -74,17 +73,10 @@ public class VelocityMessageRenderer extends CarbonMessageRenderer {
                 }
             }
         }
-        final Audience parseAudience;
 
-        if (receiver instanceof SourcedAudience sourced) {
-            if (sourced.recipient() instanceof ConsoleCarbonPlayer) {
-                parseAudience = MiniPlaceholdersUtil.wrapAudiences(miniplaceholdersConfig, sourced.sender(), sourced.sender());
-            } else {
-                parseAudience = MiniPlaceholdersUtil.wrapAudiences(miniplaceholdersConfig, sourced.recipient(), sourced.sender());
-            }
-        } else {
-            parseAudience = receiver;
-        }
+        final Audience parseAudience = receiver instanceof SourcedAudience sourced
+            ? MiniPlaceholdersUtil.wrapAudiences(miniplaceholdersConfig, sourced.recipient(), sourced.sender())
+            : receiver;
 
         return MiniMessage.miniMessage().deserialize(placeholderResolvedMessage, parseAudience, tagResolver.build());
     }


### PR DESCRIPTION
This reverts the Velocity portion of #758. It does not revert the unrelated Paper run-task change included in that PR.

For a player message rendered to console, the sender is the player who sent the message and the recipient is console. With relational MiniPlaceholders enabled, Carbon passes:

```text
(console, player)
```

MiniPlaceholders v3 treats the first audience as the principal audience. Normal audience placeholders therefore resolve for console. Player-only placeholders such as `<player_current_server>` cannot resolve, and LuckPerms cannot find a user for the console identity.

#758 replaces the console recipient with `sourced.sender()`. `sourced.sender()` is the player, not console, so it instead passes:

```text
(player, player)
```

This is why the change appeared to work: normal audience placeholders once again receive a player. However, it only works by discarding the actual recipient. Relational placeholders are also evaluated as the player's relationship with themselves.

## How we got here

Before MiniPlaceholders v3, Carbon could provide normal audience placeholders for the sender separately from relational placeholders for the recipient and sender.

The intended roles were established through several earlier fixes:

- #445 and [af12f926](https://github.com/Hexaoxide/Carbon/commit/af12f92650de92caa704be39bb10b28df97ac46b) made the recipient the first side of a relational placeholder because the message is being rendered for that recipient.
- #492 preserved normal PlaceholderAPI placeholders as sender placeholders while keeping relational placeholders ordered as `(recipient, sender)`.
- #534 reported normal MiniPlaceholders incorrectly showing each recipient's prefix. [8d24dd6e](https://github.com/Hexaoxide/Carbon/commit/8d24dd6eebbbd7ee34dc898a5f6a110322bdd2fb) fixed that by no longer allowing the relational resolver to override the separately provided sender placeholders.

#690 then updated Carbon for MiniPlaceholders v3. In v3, placeholder resolvers receive their audience from the MiniMessage parsing context. Relational placeholders require a [`RelationalAudience`](https://github.com/MiniPlaceholders/MiniPlaceholders/blob/3.1.0/api/src/main/java/io/github/miniplaceholders/api/types/RelationalAudience.java), whose first audience is also the principal used by normal audience placeholders.

This means Carbon can no longer simultaneously provide:

```text
normal audience placeholders -> sender
relational placeholders      -> recipient, sender
```

in one parse without additional parsing or format complexity. Passing `(recipient, sender)` for relational placeholders necessarily makes normal audience placeholders use the recipient too.

[91f00da3](https://github.com/Hexaoxide/Carbon/commit/91f00da371c8843c675281b37af45958d1531655) introduced the `relational-placeholders` config option and disabled it by default for this reason. [5ee2f950](https://github.com/Hexaoxide/Carbon/commit/5ee2f950121a0f13b7dfe8253c9953f586183897) then made the parsing audience follow that option.

This intentionally provides two modes:

| `relational-placeholders` | Behavior |
| --- | --- |
| `false` | Normal audience placeholders resolve for the sender. This matches user expectations for almost all common chat formats. |
| `true` | Carbon follows MiniPlaceholders' relational model using `(recipient, sender)`. Normal audience placeholders consequently resolve for the recipient, and formats may need to select the sender explicitly. |

#732 was filed against beta.36, before these two modes existed, so relational parsing was unavoidable in the latest release and the original report was reasonable. By the time #758 was merged, the config solution above was already on trunk; affected users should instead have been directed to the appropriate mode or format adjustment described below. #758 bypassed that solution by introducing a third, Velocity-console-only behavior.

## Resolution for users affected by #732

For formats like the one reported in #732, leave `relational-placeholders` disabled. If relational placeholders are actually needed, keep the option enabled and explicitly select the sender where necessary. For example, using the Expressions Provider:

```text
<expr_player:<username>:<player_current_server>>
```

or:

```text
<expr_player:<username>:<luckperms_prefix>>
```

Carbon's `render_for` tag is another option where appropriate, with the existing caveats around preprocess tags and nested MiniMessage parsing.

This revert removes the third, console-specific behavior and restores the same configured semantics for every Velocity recipient.
