### PR TITLE
Migrate nullness annotations to JSpecify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 25 ]
       fail-fast: true
     steps:
       - uses: actions/checkout@v7
@@ -121,7 +121,7 @@ jobs:
           --health-retries=3
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 25 ]
       fail-fast: true
     steps:
       - uses: actions/checkout@v7

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
   compileOnlyApi(libs.minimessage)
 
   compileOnlyApi(libs.checkerQual)
+  compileOnlyApi(libs.jetbrainsAnnotations)
+  api(libs.jspecify)
 
   // Provided by Minecraft
   compileOnlyApi(libs.gson)

--- a/api/src/main/java/net/draycia/carbon/api/CarbonChat.java
+++ b/api/src/main/java/net/draycia/carbon/api/CarbonChat.java
@@ -23,8 +23,7 @@ import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.users.UserManager;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * The {@link CarbonChat} interface is the gateway to interacting with the majority of the CarbonChat API.
@@ -39,7 +38,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  *
  * @since 1.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonChat {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/CarbonChatProvider.java
+++ b/api/src/main/java/net/draycia/carbon/api/CarbonChatProvider.java
@@ -19,17 +19,16 @@
  */
 package net.draycia.carbon.api;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Static accessor for the {@link CarbonChat} instance.
  *
  * @since 1.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatProvider {
 
     private static @Nullable CarbonChat instance;

--- a/api/src/main/java/net/draycia/carbon/api/CarbonServer.java
+++ b/api/src/main/java/net/draycia/carbon/api/CarbonServer.java
@@ -22,15 +22,14 @@ package net.draycia.carbon.api;
 import java.util.List;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.kyori.adventure.audience.Audience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * The server that carbon is running on.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonServer extends Audience {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/channels/ChannelPermissionResult.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChannelPermissionResult.java
@@ -21,15 +21,14 @@ package net.draycia.carbon.api.channels;
 
 import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents the result of a channel permission check.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ChannelPermissionResult {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/channels/ChannelPermissionResultImpl.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChannelPermissionResultImpl.java
@@ -21,10 +21,9 @@ package net.draycia.carbon.api.channels;
 
 import java.util.function.Supplier;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 record ChannelPermissionResultImpl(
     boolean permitted,
     Supplier<Component> reasonSupplier

--- a/api/src/main/java/net/draycia/carbon/api/channels/ChannelRegistry.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChannelRegistry.java
@@ -23,8 +23,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Consumer;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Registry for {@link ChatChannel chat channels}.

--- a/api/src/main/java/net/draycia/carbon/api/channels/ChatChannel.java
+++ b/api/src/main/java/net/draycia/carbon/api/channels/ChatChannel.java
@@ -24,9 +24,8 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.util.ChatComponentRenderer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Keyed;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * ChatChannel interface, supplies a formatter and filters recipients.<br>
@@ -34,7 +33,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ChatChannel extends Keyed, ChatComponentRenderer {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/CarbonEventHandler.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/CarbonEventHandler.java
@@ -19,8 +19,7 @@
  */
 package net.draycia.carbon.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * The {@link CarbonEventHandler} is responsible for managing {@link CarbonEventSubscription event subscriptions}
@@ -28,7 +27,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonEventHandler {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/CarbonEventSubscriber.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/CarbonEventSubscriber.java
@@ -19,8 +19,7 @@
  */
 package net.draycia.carbon.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * An EventSubscriber.
@@ -28,7 +27,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  * @param <T> CarbonEvent implementations
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonEventSubscriber<T extends CarbonEvent> {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/CarbonEventSubscription.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/CarbonEventSubscription.java
@@ -19,8 +19,7 @@
  */
 package net.draycia.carbon.api.event;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A subscription to a specific event type.
@@ -28,7 +27,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  * @param <T> event type
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonEventSubscription<T extends CarbonEvent> {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChannelRegisterEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChannelRegisterEvent.java
@@ -24,8 +24,7 @@ import java.util.function.Consumer;
 import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * {@link CarbonEvent} that's called after new channels are registered.
@@ -37,7 +36,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonChannelRegisterEvent extends CarbonEvent {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChatEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/CarbonChatEvent.java
@@ -29,15 +29,14 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Event that's called when chat components are rendered for online players.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonChatEvent extends CarbonEvent, Cancellable {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/CarbonPrivateChatEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/CarbonPrivateChatEvent.java
@@ -23,15 +23,14 @@ import net.draycia.carbon.api.event.Cancellable;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called whenever a player privately messages another player.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonPrivateChatEvent extends CarbonEvent, Cancellable {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/ChannelSwitchEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/ChannelSwitchEvent.java
@@ -22,15 +22,14 @@ package net.draycia.carbon.api.event.events;
 import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when a player switches channels.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ChannelSwitchEvent extends CarbonEvent {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/PartyJoinEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/PartyJoinEvent.java
@@ -23,15 +23,14 @@ import java.util.UUID;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.Party;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when a player is added to a {@link Party}.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PartyJoinEvent extends CarbonEvent {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/event/events/PartyLeaveEvent.java
+++ b/api/src/main/java/net/draycia/carbon/api/event/events/PartyLeaveEvent.java
@@ -23,15 +23,14 @@ import java.util.UUID;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.Party;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called when a player is removed from a {@link Party}.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PartyLeaveEvent extends CarbonEvent {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/users/CarbonPlayer.java
+++ b/api/src/main/java/net/draycia/carbon/api/users/CarbonPlayer.java
@@ -30,16 +30,15 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Generic abstraction for players.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface CarbonPlayer extends Audience, Identified {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/users/Party.java
+++ b/api/src/main/java/net/draycia/carbon/api/users/Party.java
@@ -22,8 +22,7 @@ package net.draycia.carbon.api.users;
 import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Reference to a chat party.
@@ -32,7 +31,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  * @see UserManager#party(UUID)
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface Party {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/users/UserManager.java
+++ b/api/src/main/java/net/draycia/carbon/api/users/UserManager.java
@@ -22,16 +22,15 @@ package net.draycia.carbon.api.users;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Manager used to load/obtain and save {@link CarbonPlayer CarbonPlayers}.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface UserManager<C extends CarbonPlayer> {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/util/ChatComponentRenderer.java
+++ b/api/src/main/java/net/draycia/carbon/api/util/ChatComponentRenderer.java
@@ -22,8 +22,7 @@ package net.draycia.carbon.api.util;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Renderer used to construct chat components on a per-player basis.
@@ -31,7 +30,7 @@ import org.checkerframework.framework.qual.DefaultQualifier;
  * @since 2.0.0
  */
 @FunctionalInterface
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ChatComponentRenderer {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/util/KeyedRenderer.java
+++ b/api/src/main/java/net/draycia/carbon/api/util/KeyedRenderer.java
@@ -21,15 +21,14 @@ package net.draycia.carbon.api.util;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A {@link ChatComponentRenderer chat renderer} that's identifiable by key.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface KeyedRenderer extends Keyed, ChatComponentRenderer {
 
     /**

--- a/api/src/main/java/net/draycia/carbon/api/util/KeyedRendererImpl.java
+++ b/api/src/main/java/net/draycia/carbon/api/util/KeyedRendererImpl.java
@@ -23,10 +23,9 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 record KeyedRendererImpl(Key key, ChatComponentRenderer renderer) implements KeyedRenderer {
 
     @Override

--- a/build-logic/src/main/kotlin/carbon.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/carbon.platform-conventions.gradle.kts
@@ -12,6 +12,8 @@ configurations.runtimeDownload {
   exclude("org.slf4j", "slf4j-api")
   exclude("com.google.errorprone", "error_prone_annotations")
   exclude("io.leangen.geantyref", "geantyref")
+  exclude("org.checkerframework", "checker-qual")
+  exclude("org.jspecify", "jspecify")
 }
 
 val platformExtension = extensions.create<CarbonPlatformExtension>("carbonPlatform")

--- a/build-logic/src/main/kotlin/extensions.kt
+++ b/build-logic/src/main/kotlin/extensions.kt
@@ -94,6 +94,7 @@ fun ShadowJar.configureShadowJar() {
     exclude(dependency("io.netty:netty-buffer"))
     exclude(dependency("it.unimi.dsi:fastutil"))
     exclude(dependency("org.checkerframework:checker-qual"))
+    exclude(dependency("org.jspecify:jspecify"))
     exclude(dependency("org.slf4j:slf4j-api"))
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ hangarPublish.publications.register("plugin") {
   }
   platforms.velocity {
     jar = project(":carbonchat-velocity").platformJar()
-    platformVersions.add("3.5")
+    platformVersions.add("4.0")
     dependencies {
       url("LuckPerms", "https://luckperms.net/")
       hangar("MiniPlaceholders") {

--- a/common/src/main/java/net/draycia/carbon/common/CarbonChatInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonChatInternal.java
@@ -48,10 +48,9 @@ import net.draycia.carbon.common.util.CloudUtils;
 import net.draycia.carbon.common.util.ConcurrentUtil;
 import net.draycia.carbon.common.util.UpdateChecker;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class CarbonChatInternal implements CarbonChat {
 
     private final Injector injector;

--- a/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonCommonModule.java
@@ -120,13 +120,12 @@ import net.kyori.adventure.text.Component;
 import net.kyori.moonshine.Moonshine;
 import net.kyori.moonshine.exception.scan.UnscannableMethodException;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jdbi.v3.core.h2.H2DatabasePlugin;
 import org.jdbi.v3.postgres.PostgresPlugin;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.util.NamingSchemes;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonCommonModule extends AbstractModule {
 
     @Provides

--- a/common/src/main/java/net/draycia/carbon/common/CarbonPlatformModule.java
+++ b/common/src/main/java/net/draycia/carbon/common/CarbonPlatformModule.java
@@ -23,10 +23,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import net.draycia.carbon.common.integration.Integration;
 import net.draycia.carbon.common.integration.miniplaceholders.MiniPlaceholdersIntegration;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class CarbonPlatformModule extends AbstractModule {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/PlatformScheduler.java
+++ b/common/src/main/java/net/draycia/carbon/common/PlatformScheduler.java
@@ -22,10 +22,9 @@ package net.draycia.carbon.common;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PlatformScheduler {
 
     void scheduleForPlayer(CarbonPlayer carbonPlayer, Runnable runnable);

--- a/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/CarbonChannelRegistry.java
@@ -70,14 +70,14 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.Command;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.minecraft.signed.SignedString;
 import org.incendo.cloud.permission.Permission;
 import org.incendo.cloud.permission.PredicatePermission;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
@@ -86,7 +86,7 @@ import org.spongepowered.configurate.transformation.ConfigurationTransformation;
 import static org.incendo.cloud.minecraft.signed.SignedGreedyStringParser.signedGreedyStringParser;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonChannelRegistry extends ChatListenerInternal implements ChannelRegistry {
 
     private final Path configChannelDir;

--- a/common/src/main/java/net/draycia/carbon/common/channels/ConfigChannelSettings.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/ConfigChannelSettings.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import net.draycia.carbon.common.channels.messages.ConfigChannelMessageSource;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Setting;

--- a/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/ConfigChatChannel.java
@@ -55,10 +55,9 @@ import net.kyori.moonshine.exception.scan.UnscannableMethodException;
 import net.kyori.moonshine.strategy.StandardPlaceholderResolverStrategy;
 import net.kyori.moonshine.strategy.supertype.StandardSupertypeThenInterfaceSupertypeStrategy;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Setting;
@@ -66,7 +65,7 @@ import org.spongepowered.configurate.objectmapping.meta.Setting;
 import static java.util.Objects.requireNonNull;
 
 @ConfigSerializable
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ConfigChatChannel implements ChatChannel {
 
     protected transient @MonotonicNonNull @Inject CarbonServer server;
@@ -145,7 +144,7 @@ public class ConfigChatChannel implements ChatChannel {
     }
 
     @Override
-    public @NotNull Component render(
+    public @NonNull Component render(
         final CarbonPlayer sender,
         final Audience recipient,
         final Component message,

--- a/common/src/main/java/net/draycia/carbon/common/channels/PartyChatChannel.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/PartyChatChannel.java
@@ -33,16 +33,15 @@ import net.draycia.carbon.common.users.WrappedCarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
 @ConfigSerializable
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PartyChatChannel extends ConfigChatChannel {
 
     public static final String FILE_NAME = "partychat.conf";
@@ -81,7 +80,7 @@ public class PartyChatChannel extends ConfigChatChannel {
     }
 
     @Override
-    public @NotNull Component render(
+    public @NonNull Component render(
         final CarbonPlayer sender,
         final Audience recipient,
         final Component message,

--- a/common/src/main/java/net/draycia/carbon/common/channels/messages/ConfigChannelMessageSource.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/messages/ConfigChannelMessageSource.java
@@ -28,15 +28,14 @@ import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.draycia.carbon.common.util.DiscordRecipient;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.moonshine.message.IMessageSource;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Setting;
 
 @ConfigSerializable
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ConfigChannelMessageSource implements IMessageSource<SourcedAudience, String> {
 
     // Map<String, String> -> Map<Group, Format>

--- a/common/src/main/java/net/draycia/carbon/common/channels/messages/ConfigChannelMessages.java
+++ b/common/src/main/java/net/draycia/carbon/common/channels/messages/ConfigChannelMessages.java
@@ -25,10 +25,9 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.moonshine.annotation.Message;
 import net.kyori.moonshine.annotation.Placeholder;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ConfigChannelMessages {
 
     // TODO: locale placeholders?

--- a/common/src/main/java/net/draycia/carbon/common/command/CarbonCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/CarbonCommand.java
@@ -21,11 +21,11 @@ package net.draycia.carbon.common.command;
 
 import java.util.Objects;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class CarbonCommand {
 
     private @Nullable CommandSettings commandSettings = null;

--- a/common/src/main/java/net/draycia/carbon/common/command/ExecutionCoordinatorHolder.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/ExecutionCoordinatorHolder.java
@@ -24,11 +24,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import net.draycia.carbon.common.util.ConcurrentUtil;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record ExecutionCoordinatorHolder(
     ExecutionCoordinator<Commander> executionCoordinator,
     ExecutorService executorService

--- a/common/src/main/java/net/draycia/carbon/common/command/ParserFactory.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/ParserFactory.java
@@ -20,10 +20,9 @@
 package net.draycia.carbon.common.command;
 
 import net.draycia.carbon.common.command.argument.CarbonPlayerParser;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ParserFactory {
 
     CarbonPlayerParser carbonPlayer();

--- a/common/src/main/java/net/draycia/carbon/common/command/PlayerCommander.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/PlayerCommander.java
@@ -20,7 +20,7 @@
 package net.draycia.carbon.common.command;
 
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jspecify.annotations.NonNull;
 
 public interface PlayerCommander extends Commander {
 

--- a/common/src/main/java/net/draycia/carbon/common/command/argument/CarbonPlayerParser.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/argument/CarbonPlayerParser.java
@@ -28,16 +28,16 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.exception.ComponentException;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.users.ProfileResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
 import org.incendo.cloud.parser.ArgumentParseResult;
 import org.incendo.cloud.parser.ArgumentParser;
 import org.incendo.cloud.parser.ParserDescriptor;
 import org.incendo.cloud.suggestion.SuggestionProvider;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonPlayerParser implements ArgumentParser.FutureArgumentParser<Commander, CarbonPlayer>, ParserDescriptor<Commander, CarbonPlayer> {
 
     private final PlayerSuggestions suggestions;

--- a/common/src/main/java/net/draycia/carbon/common/command/argument/PlayerSuggestions.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/argument/PlayerSuggestions.java
@@ -20,10 +20,9 @@
 package net.draycia.carbon.common.command.argument;
 
 import net.draycia.carbon.common.command.Commander;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.suggestion.SuggestionProvider;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PlayerSuggestions extends SuggestionProvider<Commander> {
 }

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/ClearChatCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/ClearChatCommand.java
@@ -29,13 +29,12 @@ import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ClearChatCommand extends CarbonCommand {
 
     private final CarbonServer server;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/ContinueCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/ContinueCommand.java
@@ -30,16 +30,15 @@ import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.minecraft.signed.SignedString;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.minecraft.signed.SignedGreedyStringParser.signedGreedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ContinueCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/DebugCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/DebugCommand.java
@@ -32,13 +32,12 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class DebugCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/FilterCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/FilterCommand.java
@@ -27,14 +27,13 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.BooleanParser.booleanParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class FilterCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/HelpCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/HelpCommand.java
@@ -31,8 +31,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
@@ -41,6 +39,7 @@ import org.incendo.cloud.minecraft.extras.AudienceProvider;
 import org.incendo.cloud.minecraft.extras.MinecraftHelp;
 import org.incendo.cloud.suggestion.Suggestion;
 import org.intellij.lang.annotations.Subst;
+import org.jspecify.annotations.NullMarked;
 
 import static net.kyori.adventure.text.format.NamedTextColor.DARK_GRAY;
 import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
@@ -50,7 +49,7 @@ import static org.incendo.cloud.minecraft.extras.MinecraftHelp.helpColors;
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.StringParser.greedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class HelpCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/IgnoreCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/IgnoreCommand.java
@@ -29,14 +29,13 @@ import net.draycia.carbon.common.command.ParserFactory;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class IgnoreCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/IgnoreListCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/IgnoreListCommand.java
@@ -31,16 +31,15 @@ import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.util.Pagination;
 import net.draycia.carbon.common.util.PaginationHelper;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.component.DefaultValue;
 import org.incendo.cloud.context.CommandContext;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.IntegerParser.integerParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class IgnoreListCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/JoinCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/JoinCommand.java
@@ -31,17 +31,16 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.suggestion.Suggestion;
 import org.incendo.cloud.suggestion.SuggestionProvider;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.StringParser.greedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class JoinCommand extends CarbonCommand {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
@@ -30,17 +30,16 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.suggestion.Suggestion;
 import org.incendo.cloud.suggestion.SuggestionProvider;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.StringParser.greedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class LeaveCommand extends CarbonCommand {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/MuteCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/MuteCommand.java
@@ -33,16 +33,15 @@ import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.parser.standard.DurationParser;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class MuteCommand extends CarbonCommand {
 
     private final CarbonServer server;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/MuteInfoCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/MuteInfoCommand.java
@@ -32,15 +32,14 @@ import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class MuteInfoCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/NicknameCommand.java
@@ -34,14 +34,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.StringParser.greedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class NicknameCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/PartyCommands.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/PartyCommands.java
@@ -44,18 +44,17 @@ import net.draycia.carbon.common.util.Pagination;
 import net.draycia.carbon.common.util.PaginationHelper;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.component.DefaultValue;
 import org.incendo.cloud.context.CommandContext;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.IntegerParser.integerParser;
 import static org.incendo.cloud.parser.standard.StringParser.greedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PartyCommands extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/RealNameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/RealNameCommand.java
@@ -29,14 +29,13 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.parser.standard.StringParser;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class RealNameCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/ReloadCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/ReloadCommand.java
@@ -27,13 +27,12 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.event.events.CarbonReloadEvent;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ReloadCommand extends CarbonCommand {
 
     private final CarbonEventHandler events;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/ReplyCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/ReplyCommand.java
@@ -30,16 +30,15 @@ import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.minecraft.signed.SignedString;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.minecraft.signed.SignedGreedyStringParser.signedGreedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ReplyCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/SpyCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/SpyCommand.java
@@ -27,14 +27,13 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.BooleanParser.booleanParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class SpyCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/UnignoreCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/UnignoreCommand.java
@@ -29,14 +29,13 @@ import net.draycia.carbon.common.command.ParserFactory;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class UnignoreCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/UnmuteCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/UnmuteCommand.java
@@ -29,14 +29,13 @@ import net.draycia.carbon.common.command.Commander;
 import net.draycia.carbon.common.command.ParserFactory;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class UnmuteCommand extends CarbonCommand {
 
     private final UserManager<?> users;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/UpdateUsernameCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/UpdateUsernameCommand.java
@@ -33,14 +33,13 @@ import net.draycia.carbon.common.users.CarbonPlayerCommon;
 import net.draycia.carbon.common.users.ProfileResolver;
 import net.draycia.carbon.common.users.WrappedCarbonPlayer;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
+import org.jspecify.annotations.NullMarked;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.parser.standard.UUIDParser.uuidParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class UpdateUsernameCommand extends CarbonCommand {
 
     private final UserManager<?> userManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/WhisperCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/WhisperCommand.java
@@ -47,16 +47,15 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.minecraft.signed.SignedString;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.minecraft.extras.RichDescription.richDescription;
 import static org.incendo.cloud.minecraft.signed.SignedGreedyStringParser.signedGreedyStringParser;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class WhisperCommand extends CarbonCommand {
 
     private final CommandManager<Commander> commandManager;

--- a/common/src/main/java/net/draycia/carbon/common/command/exception/CommandCompleted.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/exception/CommandCompleted.java
@@ -21,11 +21,10 @@ package net.draycia.carbon.common.command.exception;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CommandCompleted extends ComponentException {
 
     private static final long serialVersionUID = 1352215898395889299L;

--- a/common/src/main/java/net/draycia/carbon/common/command/exception/ComponentException.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/exception/ComponentException.java
@@ -23,11 +23,10 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.util.ComponentMessageThrowable;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ComponentException extends RuntimeException implements ComponentMessageThrowable {
 
     private static final long serialVersionUID = 132203031250316968L;

--- a/common/src/main/java/net/draycia/carbon/common/config/ClearChatSettings.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/ClearChatSettings.java
@@ -24,13 +24,12 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
 @ConfigSerializable
-@DefaultQualifier(NonNull.class)
+@NullMarked
 // TODO: Config versioning. This isn't automatically added to existing configs otherwise.
 public class ClearChatSettings {
 

--- a/common/src/main/java/net/draycia/carbon/common/config/CommandConfig.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/CommandConfig.java
@@ -24,24 +24,28 @@ import net.draycia.carbon.common.command.CommandSettings;
 import net.draycia.carbon.common.util.CloudUtils;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 @ConfigSerializable
-@DefaultQualifier(MonotonicNonNull.class)
+@NullMarked
 public class CommandConfig {
 
-    private Map<Key, CommandSettings> settings = CloudUtils.defaultCommandSettings();
+    private @MonotonicNonNull @Nullable Map<@MonotonicNonNull @Nullable Key, @MonotonicNonNull @Nullable CommandSettings> settings =
+        CloudUtils.defaultCommandSettings();
 
     public CommandConfig() {
 
     }
 
-    public CommandConfig(final Map<Key, CommandSettings> settings) {
+    public CommandConfig(
+        final @MonotonicNonNull @Nullable Map<@MonotonicNonNull @Nullable Key, @MonotonicNonNull @Nullable CommandSettings> settings
+    ) {
         this.settings = settings;
     }
 
-    public Map<Key, CommandSettings> settings() {
+    public @MonotonicNonNull @Nullable Map<@MonotonicNonNull @Nullable Key, @MonotonicNonNull @Nullable CommandSettings> settings() {
         return this.settings;
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/config/ConfigManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/ConfigManager.java
@@ -39,9 +39,8 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.serializer.configurate4.ConfigurateComponentSerializer;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.CommentedConfigurationNodeIntermediary;
 import org.spongepowered.configurate.ConfigurateException;
@@ -53,7 +52,7 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Processor;
 import org.spongepowered.configurate.transformation.ConfigurationTransformation;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class ConfigManager {
 

--- a/common/src/main/java/net/draycia/carbon/common/config/DatabaseSettings.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/DatabaseSettings.java
@@ -20,19 +20,19 @@
 package net.draycia.carbon.common.config;
 
 import java.util.concurrent.TimeUnit;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
-@DefaultQualifier(Nullable.class)
+@NullMarked
 @ConfigSerializable
 public class DatabaseSettings {
 
     public DatabaseSettings() {
     }
 
-    public DatabaseSettings(final String url, final String username, final String password) {
+    public DatabaseSettings(final @Nullable String url, final @Nullable String username, final @Nullable String password) {
         this.url = url;
         this.username = username;
         this.password = password;
@@ -43,34 +43,34 @@ public class DatabaseSettings {
         MySQL: jdbc:mysql://host:3306/DB
         MariaDB: jdbc:mariadb://host:3306/DB
         PostgreSQL: jdbc:postgresql://host:5432/database""")
-    private String url = "jdbc:mysql://localhost:3306/carbon";
+    private @Nullable String url = "jdbc:mysql://localhost:3306/carbon";
 
     @Comment("The connection username.")
-    private String username = "username";
+    private @Nullable String username = "username";
 
     @Comment("The connection password.")
-    private String password = "password";
+    private @Nullable String password = "password";
 
     @Comment("Settings for the connection pool. This is an advanced configuration that most users won't need to touch.")
-    private ConnectionPool connectionPool = new ConnectionPool();
+    private @Nullable ConnectionPool connectionPool = new ConnectionPool();
 
-    public String url() {
+    public @Nullable String url() {
         return this.url;
     }
 
-    public String url(final String url) {
+    public @Nullable String url(final @Nullable String url) {
         return this.url = url;
     }
 
-    public String username() {
+    public @Nullable String username() {
         return this.username;
     }
 
-    public String password() {
+    public @Nullable String password() {
         return this.password;
     }
 
-    public ConnectionPool connectionPool() {
+    public @Nullable ConnectionPool connectionPool() {
         return this.connectionPool;
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/config/IntegrationConfigContainer.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/IntegrationConfigContainer.java
@@ -28,16 +28,15 @@ import java.util.Objects;
 import java.util.Set;
 import net.draycia.carbon.common.integration.Integration;
 import net.draycia.carbon.common.util.Exceptions;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.BasicConfigurationNode;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class IntegrationConfigContainer {
 
     private final Map<String, Object> map = new HashMap<>();

--- a/common/src/main/java/net/draycia/carbon/common/config/MessagingSettings.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/MessagingSettings.java
@@ -21,12 +21,13 @@ package net.draycia.carbon.common.config;
 
 import net.draycia.carbon.common.messaging.MessagingManager;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
-@DefaultQualifier(MonotonicNonNull.class)
+@NullMarked
 @ConfigSerializable
 public class MessagingSettings {
 
@@ -36,21 +37,21 @@ public class MessagingSettings {
     @Comment("One of: RABBITMQ, NATS, REDIS")
     private MessagingManager.@NonNull BrokerType brokerType = MessagingManager.BrokerType.NONE;
 
-    private String url = "127.0.0.1";
+    private @MonotonicNonNull @Nullable String url = "127.0.0.1";
 
     private int port = 5672; // RabbitMQ 5672, NATS 4222, Redis 6379
 
     @Comment("RabbitMQ VHost")
-    private String vhost = "/"; // RabbitMQ only
+    private @MonotonicNonNull @Nullable String vhost = "/"; // RabbitMQ only
 
     @Comment("NATS credentials file")
-    private String credentialsFile = ""; // NATS only
+    private @MonotonicNonNull @Nullable String credentialsFile = ""; // NATS only
 
     @Comment("RabbitMQ username")
-    private String username = "username"; // RabbitMQ only
+    private @MonotonicNonNull @Nullable String username = "username"; // RabbitMQ only
 
     @Comment("RabbitMQ and Redis password")
-    private String password = "password"; // RabbitMQ and Redis only
+    private @MonotonicNonNull @Nullable String password = "password"; // RabbitMQ and Redis only
 
     public boolean enabled() {
         return this.enabled;
@@ -60,7 +61,7 @@ public class MessagingSettings {
         return this.brokerType;
     }
 
-    public String url() {
+    public @MonotonicNonNull @Nullable String url() {
         return this.url;
     }
 
@@ -68,19 +69,19 @@ public class MessagingSettings {
         return this.port;
     }
 
-    public String vhost() {
+    public @MonotonicNonNull @Nullable String vhost() {
         return this.vhost;
     }
 
-    public String credentialsFile() {
+    public @MonotonicNonNull @Nullable String credentialsFile() {
         return this.credentialsFile;
     }
 
-    public String username() {
+    public @MonotonicNonNull @Nullable String username() {
         return this.username;
     }
 
-    public String password() {
+    public @MonotonicNonNull @Nullable String password() {
         return this.password;
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
+++ b/common/src/main/java/net/draycia/carbon/common/config/PrimaryConfig.java
@@ -31,9 +31,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.NodePath;
@@ -42,7 +41,7 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.transformation.ConfigurationTransformation;
 
 @ConfigSerializable
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PrimaryConfig {
 
     @Comment("The default locale for plugin messages.")

--- a/common/src/main/java/net/draycia/carbon/common/event/CarbonEventHandlerImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/CarbonEventHandlerImpl.java
@@ -34,15 +34,14 @@ import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.event.CarbonEventSubscriber;
 import net.draycia.carbon.api.event.CarbonEventSubscription;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Event handler for listening to and emitting carbon events.
  *
  * @since 1.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class CarbonEventHandlerImpl implements CarbonEventHandler {
 

--- a/common/src/main/java/net/draycia/carbon/common/event/CarbonEventSubscriptionImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/CarbonEventSubscriptionImpl.java
@@ -23,10 +23,9 @@ import com.sasorio.event.EventSubscription;
 import net.draycia.carbon.api.event.CarbonEvent;
 import net.draycia.carbon.api.event.CarbonEventSubscriber;
 import net.draycia.carbon.api.event.CarbonEventSubscription;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 record CarbonEventSubscriptionImpl<T extends CarbonEvent>(
     Class<T> event,
     CarbonEventSubscriber<T> subscriber,

--- a/common/src/main/java/net/draycia/carbon/common/event/events/CarbonChatEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/CarbonChatEventImpl.java
@@ -29,16 +29,15 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Event that's called when chat components are rendered for online players.
  *
  * @since 2.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonChatEventImpl extends CancellableImpl implements CarbonChatEvent {
 
     private final List<KeyedRenderer> renderers;

--- a/common/src/main/java/net/draycia/carbon/common/event/events/CarbonPrivateChatEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/CarbonPrivateChatEventImpl.java
@@ -24,15 +24,14 @@ import net.draycia.carbon.api.event.events.CarbonPrivateChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.event.CancellableImpl;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Called whenever a player privately messages another player.
  *
  * @since 3.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonPrivateChatEventImpl extends CancellableImpl implements CarbonPrivateChatEvent {
 
     private final CarbonPlayer sender;

--- a/common/src/main/java/net/draycia/carbon/common/event/events/ChannelRegisterEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/ChannelRegisterEventImpl.java
@@ -23,10 +23,9 @@ import java.util.Set;
 import net.draycia.carbon.api.event.events.CarbonChannelRegisterEvent;
 import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record ChannelRegisterEventImpl(
     CarbonChannelRegistry channelRegistry,
     Set<Key> registered

--- a/common/src/main/java/net/draycia/carbon/common/event/events/ChannelSwitchEventImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/event/events/ChannelSwitchEventImpl.java
@@ -22,10 +22,9 @@ package net.draycia.carbon.common.event.events;
 import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.event.events.ChannelSwitchEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ChannelSwitchEventImpl implements ChannelSwitchEvent {
 
     private final CarbonPlayer player;

--- a/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersExpansion.java
+++ b/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersExpansion.java
@@ -32,11 +32,10 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class MiniPlaceholdersExpansion {
 
     private final UserManager<?> userManager;

--- a/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersIntegration.java
+++ b/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersIntegration.java
@@ -23,12 +23,11 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class MiniPlaceholdersIntegration implements Integration {
 
     private final Provider<MiniPlaceholdersExpansion> expansionProvider;

--- a/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersUtil.java
+++ b/common/src/main/java/net/draycia/carbon/common/integration/miniplaceholders/MiniPlaceholdersUtil.java
@@ -23,7 +23,7 @@ import io.github.miniplaceholders.api.MiniPlaceholders;
 import io.github.miniplaceholders.api.types.RelationalAudience;
 import java.util.Objects;
 import net.kyori.adventure.audience.Audience;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public final class MiniPlaceholdersUtil {
 

--- a/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/ChatListenerInternal.java
@@ -40,11 +40,10 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentIteratorType;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class ChatListenerInternal {
 
     private final ConfigManager configManager;

--- a/common/src/main/java/net/draycia/carbon/common/listeners/DeafenHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/DeafenHandler.java
@@ -23,10 +23,9 @@ import com.google.inject.Inject;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class DeafenHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/HyperlinkHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/HyperlinkHandler.java
@@ -22,12 +22,11 @@ package net.draycia.carbon.common.listeners;
 import com.google.inject.Inject;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static net.draycia.carbon.common.util.Strings.URL_REPLACEMENT_CONFIG;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class HyperlinkHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/IgnoreHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/IgnoreHandler.java
@@ -23,10 +23,9 @@ import com.google.inject.Inject;
 import net.draycia.carbon.api.event.CarbonEventHandler;
 import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class IgnoreHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/MessagePacketHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/MessagePacketHandler.java
@@ -31,10 +31,9 @@ import net.draycia.carbon.common.messaging.ServerId;
 import net.draycia.carbon.common.messaging.packets.ChatMessagePacket;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class MessagePacketHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/MuteHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/MuteHandler.java
@@ -27,13 +27,12 @@ import net.draycia.carbon.api.util.KeyedRenderer;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static net.draycia.carbon.api.util.KeyedRenderer.keyedRenderer;
 import static net.kyori.adventure.key.Key.key;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class MuteHandler implements Listener {
 
     private final Key muteKey = key("carbon", "mute");

--- a/common/src/main/java/net/draycia/carbon/common/listeners/PartyChatSpyHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/PartyChatSpyHandler.java
@@ -30,11 +30,10 @@ import net.draycia.carbon.api.users.Party;
 import net.draycia.carbon.common.channels.PartyChatChannel;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PartyChatSpyHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/PartyPingHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/PartyPingHandler.java
@@ -28,11 +28,10 @@ import net.draycia.carbon.common.config.ConfigManager;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.sound.Sound;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PartyPingHandler implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/PingHandler.java
@@ -32,13 +32,12 @@ import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static net.draycia.carbon.api.util.KeyedRenderer.keyedRenderer;
 import static net.kyori.adventure.key.Key.key;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public class PingHandler implements Listener {
 

--- a/common/src/main/java/net/draycia/carbon/common/listeners/RadiusListener.java
+++ b/common/src/main/java/net/draycia/carbon/common/listeners/RadiusListener.java
@@ -27,10 +27,9 @@ import net.draycia.carbon.api.event.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.messages.CarbonMessages;
 import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class RadiusListener implements Listener {
 
     @Inject

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageRenderer.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageRenderer.java
@@ -27,11 +27,10 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.moonshine.message.IMessageRenderer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class CarbonMessageRenderer implements IMessageRenderer<Audience, String, Component, Object> {
 
     private final RenderForTagResolver.Factory renderForTagResolver;

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSender.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSender.java
@@ -22,10 +22,9 @@ package net.draycia.carbon.common.messages;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.moonshine.message.IMessageSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonMessageSender implements IMessageSender<Audience, Component> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/CarbonMessageSource.java
@@ -57,12 +57,12 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.translation.Translator;
 import net.kyori.moonshine.message.IMessageSource;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonMessageSource implements IMessageSource<Audience, String> {
 
     private final Locale defaultLocale;

--- a/common/src/main/java/net/draycia/carbon/common/messages/OptionTagResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/OptionTagResolver.java
@@ -24,11 +24,10 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class OptionTagResolver implements TagResolver {
 
     private final String name;

--- a/common/src/main/java/net/draycia/carbon/common/messages/RenderForTagResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/RenderForTagResolver.java
@@ -35,11 +35,10 @@ import net.kyori.adventure.text.minimessage.ParsingException;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.ArgumentQueue;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class RenderForTagResolver implements TagResolver {
 
     private static final String TAG_NAME = "render_for";

--- a/common/src/main/java/net/draycia/carbon/common/messages/SourcedAudience.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/SourcedAudience.java
@@ -21,13 +21,12 @@ package net.draycia.carbon.common.messages;
 
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * An audience, where messages are sent from another Audience.
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface SourcedAudience extends ForwardingAudience.Single {
 
     /**

--- a/common/src/main/java/net/draycia/carbon/common/messages/SourcedMessageSender.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/SourcedMessageSender.java
@@ -21,10 +21,9 @@ package net.draycia.carbon.common.messages;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.moonshine.message.IMessageSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class SourcedMessageSender implements IMessageSender<SourcedAudience, Component> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/messages/SourcedReceiverResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/SourcedReceiverResolver.java
@@ -25,12 +25,11 @@ import java.lang.reflect.Type;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.moonshine.receiver.IReceiverLocator;
 import net.kyori.moonshine.receiver.IReceiverLocatorResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class SourcedReceiverResolver implements IReceiverLocatorResolver<SourcedAudience> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/messages/StandardPlaceholderResolverStrategyButDifferent.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/StandardPlaceholderResolverStrategyButDifferent.java
@@ -36,7 +36,7 @@ import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.strategy.IPlaceholderResolverStrategy;
 import net.kyori.moonshine.strategy.supertype.ISupertypeStrategy;
 import net.kyori.moonshine.strategy.supertype.StandardSupertypeThenInterfaceSupertypeStrategy;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.util.NamingScheme;
 
 import static java.util.Collections.emptyNavigableSet;

--- a/common/src/main/java/net/draycia/carbon/common/messages/TagPermissions.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/TagPermissions.java
@@ -27,11 +27,10 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class TagPermissions {
 
     public static final String NICKNAME = "carbon.nickname.tags";

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/BooleanPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/BooleanPlaceholderResolver.java
@@ -27,7 +27,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class BooleanPlaceholderResolver<R> implements IPlaceholderResolver<R, Boolean, Tag> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/ComponentPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/ComponentPlaceholderResolver.java
@@ -28,11 +28,10 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ComponentPlaceholderResolver<R> implements IPlaceholderResolver<R, Component, Tag> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/IntPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/IntPlaceholderResolver.java
@@ -27,7 +27,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class IntPlaceholderResolver<R> implements IPlaceholderResolver<R, Integer, Tag> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/KeyPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/KeyPlaceholderResolver.java
@@ -28,7 +28,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class KeyPlaceholderResolver<R> implements IPlaceholderResolver<R, Key, Tag> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/LongPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/LongPlaceholderResolver.java
@@ -27,7 +27,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class LongPlaceholderResolver<R> implements IPlaceholderResolver<R, Long, Tag> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/OptionPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/OptionPlaceholderResolver.java
@@ -29,7 +29,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public final class OptionPlaceholderResolver<R> implements IPlaceholderResolver<R, Option, TagResolver> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/StringPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/StringPlaceholderResolver.java
@@ -27,7 +27,7 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class StringPlaceholderResolver<R> implements IPlaceholderResolver<R, String, Tag> {
 

--- a/common/src/main/java/net/draycia/carbon/common/messages/placeholders/UUIDPlaceholderResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/messages/placeholders/UUIDPlaceholderResolver.java
@@ -28,11 +28,10 @@ import net.kyori.moonshine.placeholder.ConclusionValue;
 import net.kyori.moonshine.placeholder.ContinuanceValue;
 import net.kyori.moonshine.placeholder.IPlaceholderResolver;
 import net.kyori.moonshine.util.Either;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class UUIDPlaceholderResolver<R> implements IPlaceholderResolver<R, UUID, Tag> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/messaging/CarbonChatPacketHandler.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/CarbonChatPacketHandler.java
@@ -48,11 +48,10 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import ninja.egg82.messenger.handler.AbstractMessagingHandler;
 import ninja.egg82.messenger.packets.Packet;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatPacketHandler extends AbstractMessagingHandler {
 
     private final CarbonEventHandler events;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/MessagingManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/MessagingManager.java
@@ -74,11 +74,11 @@ import ninja.egg82.messenger.packets.server.ShutdownPacket;
 import ninja.egg82.messenger.services.PacketService;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class MessagingManager {
 
     private static final byte protocolVersion = 1;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/CarbonPacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/CarbonPacket.java
@@ -30,13 +30,13 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import ninja.egg82.messenger.packets.AbstractPacket;
 import org.intellij.lang.annotations.Subst;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public abstract class CarbonPacket extends AbstractPacket {
 
     private final GsonComponentSerializer componentSerializer = GsonComponentSerializer.gson();
 
-    protected CarbonPacket(final @NotNull UUID sender) {
+    protected CarbonPacket(final @NonNull UUID sender) {
         super(sender);
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/ChatMessagePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/ChatMessagePacket.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import ninja.egg82.messenger.utils.UUIDUtil;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
 public final class ChatMessagePacket extends CarbonPacket {
 
@@ -55,7 +55,7 @@ public final class ChatMessagePacket extends CarbonPacket {
         return this.message;
     }
 
-    public ChatMessagePacket(final @NotNull UUID sender, final @NotNull ByteBuf data) {
+    public ChatMessagePacket(final @NonNull UUID sender, final @NonNull ByteBuf data) {
         super(sender);
         this.read(data);
     }
@@ -65,7 +65,7 @@ public final class ChatMessagePacket extends CarbonPacket {
     }
 
     public ChatMessagePacket(
-        final @NotNull UUID serverId,
+        final @NonNull UUID serverId,
         final UUID userId,
         final Key channelKey,
         final String username,
@@ -79,7 +79,7 @@ public final class ChatMessagePacket extends CarbonPacket {
     }
 
     @Override
-    public void read(final io.netty.buffer.@NotNull ByteBuf buffer) {
+    public void read(final io.netty.buffer.@NonNull ByteBuf buffer) {
         this.userId = this.readUUID(buffer);
         this.channelKey = this.readKey(buffer);
         this.username = this.readString(buffer);
@@ -87,7 +87,7 @@ public final class ChatMessagePacket extends CarbonPacket {
     }
 
     @Override
-    public void write(final io.netty.buffer.@NotNull ByteBuf buffer) {
+    public void write(final io.netty.buffer.@NonNull ByteBuf buffer) {
         this.writeUUID(this.userId, buffer);
         this.writeKey(this.channelKey, buffer);
         this.writeString(this.username, buffer);

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/DisbandPartyPacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/DisbandPartyPacket.java
@@ -25,10 +25,9 @@ import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class DisbandPartyPacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID partyId;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/InvalidatePartyInvitePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/InvalidatePartyInvitePacket.java
@@ -25,10 +25,9 @@ import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class InvalidatePartyInvitePacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID from;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
@@ -51,14 +51,6 @@ public final class LocalPlayerChangePacket extends CarbonPacket {
         this.changeType = changeType;
     }
 
-    @AssistedInject
-    public LocalPlayerChangePacket(final @ServerId UUID serverId, final @Assisted UUID playerId) {
-        super(serverId);
-        this.playerId = playerId;
-        this.playerName = null;
-        this.changeType = ChangeType.REMOVE;
-    }
-
     public LocalPlayerChangePacket(final UUID sender, final ByteBuf data) {
         super(sender);
         this.read(data);

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayerChangePacket.java
@@ -25,11 +25,10 @@ import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class LocalPlayerChangePacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID playerId;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayersPacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/LocalPlayersPacket.java
@@ -26,10 +26,9 @@ import java.util.Map;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class LocalPlayersPacket extends CarbonPacket {
 
     private @MonotonicNonNull Map<UUID, String> players;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
@@ -44,7 +44,9 @@ public interface PacketFactory {
         return this.localPlayerChangePacket(id, name, LocalPlayerChangePacket.ChangeType.ADD);
     }
 
-    LocalPlayerChangePacket removeLocalPlayerPacket(final UUID id);
+    default LocalPlayerChangePacket removeLocalPlayerPacket(final UUID id) {
+        return this.localPlayerChangePacket(id, null, LocalPlayerChangePacket.ChangeType.REMOVE);
+    }
 
     WhisperPacket whisperPacket(@Assisted("from") UUID from, @Assisted("to") UUID to, Component msg);
 

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/PacketFactory.java
@@ -24,11 +24,10 @@ import java.util.Map;
 import java.util.UUID;
 import net.draycia.carbon.common.users.PartyImpl;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PacketFactory {
 
     SaveCompletedPacket saveCompletedPacket(UUID playerId);

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/PartyChangePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/PartyChangePacket.java
@@ -27,10 +27,9 @@ import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import net.draycia.carbon.common.users.PartyImpl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PartyChangePacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID partyId;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/PartyInvitePacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/PartyInvitePacket.java
@@ -25,10 +25,9 @@ import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PartyInvitePacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID from;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/SaveCompletedPacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/SaveCompletedPacket.java
@@ -25,10 +25,9 @@ import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class SaveCompletedPacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID player;

--- a/common/src/main/java/net/draycia/carbon/common/messaging/packets/WhisperPacket.java
+++ b/common/src/main/java/net/draycia/carbon/common/messaging/packets/WhisperPacket.java
@@ -26,10 +26,9 @@ import java.util.UUID;
 import net.draycia.carbon.common.messaging.ServerId;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class WhisperPacket extends CarbonPacket {
 
     private @MonotonicNonNull UUID from;

--- a/common/src/main/java/net/draycia/carbon/common/serialisation/gson/ChatChannelSerializerGson.java
+++ b/common/src/main/java/net/draycia/carbon/common/serialisation/gson/ChatChannelSerializerGson.java
@@ -26,14 +26,13 @@ import com.google.inject.Inject;
 import java.io.IOException;
 import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.channels.ChatChannel;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.intellij.lang.annotations.Subst;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.kyori.adventure.key.Key.key;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ChatChannelSerializerGson extends TypeAdapter<ChatChannel> {
 
     private final ChannelRegistry registry;

--- a/common/src/main/java/net/draycia/carbon/common/serialisation/gson/LocaleSerializerConfigurate.java
+++ b/common/src/main/java/net/draycia/carbon/common/serialisation/gson/LocaleSerializerConfigurate.java
@@ -24,16 +24,15 @@ import java.lang.reflect.Type;
 import java.util.Locale;
 import net.kyori.adventure.translation.Translator;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class LocaleSerializerConfigurate implements TypeSerializer<Locale> {
 
     private final Logger logger;

--- a/common/src/main/java/net/draycia/carbon/common/serialisation/gson/UUIDSerializerGson.java
+++ b/common/src/main/java/net/draycia/carbon/common/serialisation/gson/UUIDSerializerGson.java
@@ -24,11 +24,10 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.UUID;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class UUIDSerializerGson extends TypeAdapter<UUID> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/users/CachingUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/CachingUserManager.java
@@ -50,13 +50,12 @@ import net.draycia.carbon.common.users.db.DatabaseUserManager;
 import net.draycia.carbon.common.util.ConcurrentUtil;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.draycia.carbon.common.users.PlayerUtils.saveExceptionHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class CachingUserManager implements UserManagerInternal<CarbonPlayerCommon> {
 
     private static final int DISBAND_DELAY = 10;

--- a/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/CarbonPlayerCommon.java
@@ -46,11 +46,10 @@ import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonPlayerCommon implements CarbonPlayer, ForwardingAudience.Single {
 
     private static final long KEEP_TRANSIENT_LOADS_FOR = Duration.ofMinutes(2).toMillis();

--- a/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/ConsoleCarbonPlayer.java
@@ -34,12 +34,11 @@ import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class ConsoleCarbonPlayer implements CarbonPlayer, ForwardingAudience.Single {
 
     private final Audience audience;
@@ -49,7 +48,7 @@ public class ConsoleCarbonPlayer implements CarbonPlayer, ForwardingAudience.Sin
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.audience;
     }
 
@@ -274,7 +273,7 @@ public class ConsoleCarbonPlayer implements CarbonPlayer, ForwardingAudience.Sin
     }
 
     @Override
-    public @NotNull Identity identity() {
+    public @NonNull Identity identity() {
         return Identity.nil();
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/users/MojangProfileResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/MojangProfileResolver.java
@@ -46,11 +46,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.draycia.carbon.common.util.ConcurrentUtil;
 import net.draycia.carbon.common.util.FastUuidSansHyphens;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class MojangProfileResolver implements ProfileResolver {
 
     private final HttpClient client;

--- a/common/src/main/java/net/draycia/carbon/common/users/NetworkUsers.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/NetworkUsers.java
@@ -39,19 +39,18 @@ import net.draycia.carbon.common.command.argument.PlayerSuggestions;
 import net.draycia.carbon.common.messaging.packets.LocalPlayerChangePacket;
 import net.draycia.carbon.common.messaging.packets.LocalPlayersPacket;
 import net.draycia.carbon.common.util.Exceptions;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
 import org.incendo.cloud.suggestion.Suggestion;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Eventually consistent store of who is on each server in the network (besides self).
  *
  * <p>Currently used for username suggestions and whispers.</p>
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class NetworkUsers implements PlayerSuggestions {
 

--- a/common/src/main/java/net/draycia/carbon/common/users/PartyImpl.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/PartyImpl.java
@@ -40,11 +40,10 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PartyImpl implements Party {
 
     private final Component name;

--- a/common/src/main/java/net/draycia/carbon/common/users/PartyInvites.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/PartyInvites.java
@@ -38,11 +38,10 @@ import net.draycia.carbon.common.messaging.packets.InvalidatePartyInvitePacket;
 import net.draycia.carbon.common.messaging.packets.PacketFactory;
 import net.draycia.carbon.common.messaging.packets.PartyInvitePacket;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class PartyInvites {
 

--- a/common/src/main/java/net/draycia/carbon/common/users/PersistentUserProperty.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/PersistentUserProperty.java
@@ -31,12 +31,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PersistentUserProperty<T> {
 
     private final AtomicReference<@Nullable T> valueReference;

--- a/common/src/main/java/net/draycia/carbon/common/users/PlatformUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/PlatformUserManager.java
@@ -30,12 +30,11 @@ import net.draycia.carbon.api.users.Party;
 import net.draycia.carbon.common.messaging.packets.DisbandPartyPacket;
 import net.draycia.carbon.common.messaging.packets.PartyChangePacket;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PlatformUserManager implements UserManagerInternal<WrappedCarbonPlayer> {
 
     private final UserManagerInternal<CarbonPlayerCommon> backingManager;

--- a/common/src/main/java/net/draycia/carbon/common/users/PlayerUtils.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/PlayerUtils.java
@@ -26,11 +26,10 @@ import java.util.function.Function;
 import net.draycia.carbon.api.CarbonServer;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PlayerUtils {
 
     private PlayerUtils() {

--- a/common/src/main/java/net/draycia/carbon/common/users/ProfileCache.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/ProfileCache.java
@@ -40,12 +40,11 @@ import java.util.UUID;
 import net.draycia.carbon.common.DataDirectory;
 import net.draycia.carbon.common.serialisation.gson.UUIDSerializerGson;
 import net.draycia.carbon.common.util.FileUtil;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.loader.AtomicFiles;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class ProfileCache {
 

--- a/common/src/main/java/net/draycia/carbon/common/users/ProfileResolver.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/ProfileResolver.java
@@ -21,11 +21,10 @@ package net.draycia.carbon.common.users;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface ProfileResolver {
 
     CompletableFuture<@Nullable UUID> resolveUUID(String username, boolean cacheOnly);

--- a/common/src/main/java/net/draycia/carbon/common/users/UserManagerInternal.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/UserManagerInternal.java
@@ -25,10 +25,9 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.UserManager;
 import net.draycia.carbon.common.messaging.packets.DisbandPartyPacket;
 import net.draycia.carbon.common.messaging.packets.PartyChangePacket;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface UserManagerInternal<C extends CarbonPlayer> extends UserManager<C> {
 
     void shutdown();

--- a/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/WrappedCarbonPlayer.java
@@ -46,14 +46,13 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.util.Tristate;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNullElse;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public abstract class WrappedCarbonPlayer implements CarbonPlayer {
 
     protected final CarbonPlayerCommon carbonPlayerCommon;
@@ -353,7 +352,7 @@ public abstract class WrappedCarbonPlayer implements CarbonPlayer {
     }
 
     @Override
-    public @NotNull Identity identity() {
+    public @NonNull Identity identity() {
         return this.carbonPlayerCommon.identity();
     }
 

--- a/common/src/main/java/net/draycia/carbon/common/users/db/DatabaseUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/DatabaseUserManager.java
@@ -54,9 +54,6 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.logging.Log;
 import org.flywaydb.core.api.logging.LogCreator;
@@ -66,8 +63,10 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.PreparedBatch;
 import org.jdbi.v3.core.statement.Update;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class DatabaseUserManager extends CachingUserManager {
 
     private final Jdbi jdbi;

--- a/common/src/main/java/net/draycia/carbon/common/users/db/QueriesLocator.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/QueriesLocator.java
@@ -26,12 +26,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.common.config.PrimaryConfig;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jdbi.v3.core.locator.ClasspathSqlLocator;
 import org.jdbi.v3.core.locator.internal.ClasspathBuilder;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class QueriesLocator {
 
     private static final String PREFIX = "queries/";

--- a/common/src/main/java/net/draycia/carbon/common/users/db/mapper/BinaryUUIDColumnMapper.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/mapper/BinaryUUIDColumnMapper.java
@@ -24,9 +24,9 @@ import java.sql.SQLException;
 import java.util.UUID;
 import net.draycia.carbon.common.util.FastUuidSansHyphens;
 import net.draycia.carbon.common.util.Strings;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jspecify.annotations.Nullable;
 
 public final class BinaryUUIDColumnMapper implements ColumnMapper<UUID> {
 

--- a/common/src/main/java/net/draycia/carbon/common/users/db/mapper/KeyColumnMapper.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/mapper/KeyColumnMapper.java
@@ -23,10 +23,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import net.draycia.carbon.common.util.Strings;
 import net.kyori.adventure.key.Key;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.intellij.lang.annotations.Subst;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jspecify.annotations.Nullable;
 
 public final class KeyColumnMapper implements ColumnMapper<Key> {
 

--- a/common/src/main/java/net/draycia/carbon/common/users/db/mapper/PartyRowMapper.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/mapper/PartyRowMapper.java
@@ -24,13 +24,12 @@ import java.sql.SQLException;
 import java.util.UUID;
 import net.draycia.carbon.common.users.PartyImpl;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PartyRowMapper implements RowMapper<PartyImpl> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/users/db/mapper/PlayerRowMapper.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/db/mapper/PlayerRowMapper.java
@@ -25,13 +25,12 @@ import java.util.UUID;
 import net.draycia.carbon.common.users.CarbonPlayerCommon;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.jdbi.v3.core.mapper.ColumnMapper;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PlayerRowMapper implements RowMapper<CarbonPlayerCommon> {
 
     @Override

--- a/common/src/main/java/net/draycia/carbon/common/users/json/JSONUserManager.java
+++ b/common/src/main/java/net/draycia/carbon/common/users/json/JSONUserManager.java
@@ -48,11 +48,10 @@ import net.draycia.carbon.common.util.Exceptions;
 import net.draycia.carbon.common.util.FileUtil;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class JSONUserManager extends CachingUserManager {
 
     private final Gson serializer;

--- a/common/src/main/java/net/draycia/carbon/common/util/CarbonDependencies.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/CarbonDependencies.java
@@ -21,8 +21,7 @@ package net.draycia.carbon.common.util;
 
 import java.nio.file.Path;
 import java.util.Set;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import xyz.jpenilla.gremlin.runtime.DependencyCache;
@@ -30,7 +29,7 @@ import xyz.jpenilla.gremlin.runtime.DependencyResolver;
 import xyz.jpenilla.gremlin.runtime.DependencySet;
 import xyz.jpenilla.gremlin.runtime.logging.Slf4jGremlinLogger;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonDependencies {
 
     private CarbonDependencies() {

--- a/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/CloudUtils.java
@@ -40,9 +40,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.util.ComponentMessageThrowable;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.exception.ArgumentParseException;
 import org.incendo.cloud.exception.CommandExecutionException;
@@ -50,10 +47,12 @@ import org.incendo.cloud.exception.InvalidCommandSenderException;
 import org.incendo.cloud.exception.InvalidSyntaxException;
 import org.incendo.cloud.exception.NoPermissionException;
 import org.incendo.cloud.util.TypeUtils;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static org.incendo.cloud.exception.handling.ExceptionHandler.unwrappingHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CloudUtils {
 
     private static final Component NULL = Component.text("null");

--- a/common/src/main/java/net/draycia/carbon/common/util/ColorUtils.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/ColorUtils.java
@@ -25,16 +25,15 @@ import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyFormat;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Basic color related utilities.
  *
  * @since 1.0.0
  */
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ColorUtils {
 
     private static final Pattern spigotLegacyRGB =

--- a/common/src/main/java/net/draycia/carbon/common/util/ConcurrentUtil.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/ConcurrentUtil.java
@@ -25,10 +25,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ConcurrentUtil {
 
     private ConcurrentUtil() {

--- a/common/src/main/java/net/draycia/carbon/common/util/EmptyAudienceWithPointers.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/EmptyAudienceWithPointers.java
@@ -24,10 +24,9 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class EmptyAudienceWithPointers implements ForwardingAudience.Single {
 
     private final Pointers pointers;

--- a/common/src/main/java/net/draycia/carbon/common/util/ExceptionLoggingScheduledThreadPoolExecutor.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/ExceptionLoggingScheduledThreadPoolExecutor.java
@@ -25,10 +25,9 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class ExceptionLoggingScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
     private final Logger logger;

--- a/common/src/main/java/net/draycia/carbon/common/util/Exceptions.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/Exceptions.java
@@ -20,10 +20,9 @@
 package net.draycia.carbon.common.util;
 
 import java.util.function.Consumer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class Exceptions {
 
     private Exceptions() {

--- a/common/src/main/java/net/draycia/carbon/common/util/Pagination.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/Pagination.java
@@ -28,13 +28,12 @@ import java.util.RandomAccess;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static java.util.Objects.requireNonNull;
 import static net.kyori.adventure.text.Component.empty;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface Pagination<T> {
 
     ComponentLike header(int page, int pages);

--- a/common/src/main/java/net/draycia/carbon/common/util/PaginationHelper.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/PaginationHelper.java
@@ -25,15 +25,14 @@ import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
 import net.kyori.adventure.text.TextComponent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.space;
 import static net.kyori.adventure.text.Component.text;
 import static net.kyori.adventure.text.event.ClickEvent.runCommand;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PaginationHelper {
 
     private final CarbonMessages messages;

--- a/common/src/main/java/net/draycia/carbon/common/util/Strings.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/Strings.java
@@ -26,11 +26,10 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class Strings {
 
     private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/([A-Za-z0-9\\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*)?");

--- a/common/src/main/java/net/draycia/carbon/common/util/UpdateChecker.java
+++ b/common/src/main/java/net/draycia/carbon/common/util/UpdateChecker.java
@@ -36,11 +36,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.Manifest;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record UpdateChecker(Logger logger) {
 
     private static final String GITHUB_REPO = "Hexaoxide/Carbon";

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
   runtimeOnly(libs.jarRelocator) {
     isTransitive = false
   }
-  runtimeDownload(libs.checkerQual)
 }
 
 fabricModJson {
@@ -89,12 +88,10 @@ tasks {
     relocateDependency("org.incendo.cloud.minecraft.extras")
     standardRuntimeRelocations()
     relocateGuice()
-    relocateDependency("org.checkerframework")
   }
   writeDependencies {
     standardRuntimeRelocations()
     relocateGuice()
-    relocateDependency("org.checkerframework")
   }
 
   runServer {

--- a/fabric/src/main/java/net/draycia/carbon/fabric/CarbonChatFabric.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/CarbonChatFabric.java
@@ -46,10 +46,9 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class CarbonChatFabric extends CarbonChatInternal {
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/CarbonChatFabricModule.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/CarbonChatFabricModule.java
@@ -56,13 +56,12 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerPlayer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.SenderMapper;
 import org.incendo.cloud.fabric.FabricServerCommandManager;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatFabricModule extends CarbonPlatformModule {
 
     private final Logger logger;

--- a/fabric/src/main/java/net/draycia/carbon/fabric/CarbonServerFabric.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/CarbonServerFabric.java
@@ -30,12 +30,11 @@ import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonServerFabric implements CarbonServer, ForwardingAudience.Single {
 
     private final MinecraftServerHolder serverHolder;
@@ -48,7 +47,7 @@ public final class CarbonServerFabric implements CarbonServer, ForwardingAudienc
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return MinecraftServerAudiences.of(this.serverHolder.requireServer()).all();
     }
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/FabricMessageRenderer.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/FabricMessageRenderer.java
@@ -32,11 +32,10 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public class FabricMessageRenderer extends CarbonMessageRenderer {
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/FabricScheduler.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/FabricScheduler.java
@@ -23,10 +23,9 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.PlatformScheduler;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class FabricScheduler implements PlatformScheduler {
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/MinecraftServerHolder.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/MinecraftServerHolder.java
@@ -24,11 +24,10 @@ import com.google.inject.Singleton;
 import java.util.Objects;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.MinecraftServer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class MinecraftServerHolder {
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/command/FabricCommander.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/command/FabricCommander.java
@@ -24,10 +24,9 @@ import net.draycia.carbon.common.command.Commander;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.minecraft.commands.CommandSourceStack;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface FabricCommander extends Commander, ForwardingAudience.Single {
 
     static FabricCommander from(final CommandSourceStack commandSourceStack) {

--- a/fabric/src/main/java/net/draycia/carbon/fabric/command/FabricPlayerCommander.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/command/FabricPlayerCommander.java
@@ -26,12 +26,11 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.level.ServerPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record FabricPlayerCommander(
     CarbonChat carbon,
     CommandSourceStack commandSourceStack

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricChatHandler.java
@@ -45,7 +45,7 @@ import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public class FabricChatHandler extends ChatListenerInternal implements ServerMessageEvents.AllowChatMessage {
 

--- a/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricJoinQuitListener.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/listeners/FabricJoinQuitListener.java
@@ -33,13 +33,12 @@ import net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacke
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.draycia.carbon.common.users.PlayerUtils.saveExceptionHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class FabricJoinQuitListener implements ServerPlayConnectionEvents.Join, ServerPlayConnectionEvents.Disconnect {
 
     private final ProfileCache profileCache;

--- a/fabric/src/main/java/net/draycia/carbon/fabric/users/CarbonPlayerFabric.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/users/CarbonPlayerFabric.java
@@ -42,11 +42,11 @@ import net.kyori.adventure.text.format.TextColor;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonPlayerFabric extends WrappedCarbonPlayer implements ForwardingAudience.Single {
 
     private final MinecraftServerHolder serverHolder;

--- a/fabric/src/main/java/net/draycia/carbon/fabric/users/FabricProfileResolver.java
+++ b/fabric/src/main/java/net/draycia/carbon/fabric/users/FabricProfileResolver.java
@@ -27,12 +27,11 @@ import net.draycia.carbon.common.users.MojangProfileResolver;
 import net.draycia.carbon.common.users.ProfileResolver;
 import net.draycia.carbon.fabric.MinecraftServerHolder;
 import net.minecraft.server.level.ServerPlayer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class FabricProfileResolver implements ProfileResolver {
 
     private final MinecraftServerHolder serverHolder;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ cloudModded = "2.0.0-beta.15"
 cloudSponge = "2.0.0-SNAPSHOT"
 configurate = "4.2.0"
 checkerQual = "3.49.2"
+jspecify = "1.0.0"
+jetbrainsAnnotations = "26.0.2"
 stylecheck = "0.2.1"
 bstats = "3.2.1"
 paperApi = "1.21.4-R0.1-SNAPSHOT"
@@ -34,7 +36,7 @@ event = "1.0.0"
 registry = "1.0.0-SNAPSHOT"
 kyoriMoonshine = "2.0.4"
 guice = "7.0.0"
-velocityApi = "3.5.0-SNAPSHOT"
+velocityApi = "4.0.0-SNAPSHOT"
 minecraft = "1.21.11"
 fabricLoader = "0.19.3"
 fabricApi = "0.141.4+1.21.11"
@@ -113,6 +115,8 @@ configurateHocon = { group = "org.spongepowered", name = "configurate-hocon", ve
 configurateYaml = { group = "org.spongepowered", name = "configurate-yaml", version.ref = "configurate" }
 
 checkerQual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerQual" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
+jetbrainsAnnotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrainsAnnotations" }
 stylecheck = { group = "ca.stellardrift", name = "stylecheck", version.ref = "stylecheck" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -143,7 +143,3 @@ carbonPermission.permissions.get().forEach {
 publishMods.modrinth {
   modLoaders.addAll("paper", "folia")
 }
-
-configurations.runtimeDownload {
-  exclude("org.checkerframework", "checker-qual")
-}

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaper.java
@@ -50,10 +50,9 @@ import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public final class CarbonChatPaper extends CarbonChatInternal {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaperModule.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonChatPaperModule.java
@@ -60,13 +60,12 @@ import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.SenderMapper;
 import org.incendo.cloud.paper.LegacyPaperCommandManager;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatPaperModule extends CarbonPlatformModule {
 
     private final Logger logger = LogManager.getLogger("CarbonChat");

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonPaperBootstrap.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonPaperBootstrap.java
@@ -23,10 +23,9 @@ import com.google.inject.Guice;
 import net.draycia.carbon.api.CarbonChatProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonPaperBootstrap extends JavaPlugin {
 
     private @MonotonicNonNull CarbonChatPaper carbonChat;

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonPaperLoader.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonPaperLoader.java
@@ -22,11 +22,10 @@ package net.draycia.carbon.paper;
 import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
 import io.papermc.paper.plugin.loader.PluginLoader;
 import net.draycia.carbon.common.util.CarbonDependencies;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import xyz.jpenilla.gremlin.runtime.platformsupport.PaperClasspathAppender;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonPaperLoader implements PluginLoader {
 
     @Override

--- a/paper/src/main/java/net/draycia/carbon/paper/CarbonServerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/CarbonServerPaper.java
@@ -30,11 +30,10 @@ import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import org.bukkit.Server;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonServerPaper implements CarbonServer, ForwardingAudience.Single {
 
     private final Server server;

--- a/paper/src/main/java/net/draycia/carbon/paper/PaperScheduler.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/PaperScheduler.java
@@ -26,12 +26,11 @@ import net.draycia.carbon.common.PlatformScheduler;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PaperScheduler implements PlatformScheduler {
 
     private static final boolean FOLIA;

--- a/paper/src/main/java/net/draycia/carbon/paper/command/PaperCommander.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/command/PaperCommander.java
@@ -23,10 +23,9 @@ import net.draycia.carbon.common.command.Commander;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import org.bukkit.command.CommandSender;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface PaperCommander extends Commander, ForwardingAudience.Single {
 
     static PaperCommander from(final CommandSender sender) {

--- a/paper/src/main/java/net/draycia/carbon/paper/command/PaperPlayerCommander.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/command/PaperPlayerCommander.java
@@ -25,12 +25,11 @@ import net.draycia.carbon.common.command.PlayerCommander;
 import net.kyori.adventure.audience.Audience;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record PaperPlayerCommander(
     UserManager<?> userManager,
     Player player

--- a/paper/src/main/java/net/draycia/carbon/paper/hooks/CarbonPAPIPlaceholders.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/hooks/CarbonPAPIPlaceholders.java
@@ -35,11 +35,10 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class CarbonPAPIPlaceholders extends PlaceholderExpansion {
 
     private final UserManager<?> userManager;

--- a/paper/src/main/java/net/draycia/carbon/paper/hooks/PAPIChatHook.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/hooks/PAPIChatHook.java
@@ -27,10 +27,9 @@ import net.draycia.carbon.common.listeners.Listener;
 import net.draycia.carbon.common.util.ColorUtils;
 import net.draycia.carbon.paper.CarbonChatPaper;
 import net.draycia.carbon.paper.users.CarbonPlayerPaper;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PAPIChatHook implements Listener {
 
     @Inject

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/alessiodp_parties/AlessiodpPartiesIntegration.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/alessiodp_parties/AlessiodpPartiesIntegration.java
@@ -25,12 +25,11 @@ import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class AlessiodpPartiesIntegration implements Integration {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/alessiodp_parties/AlessiodpPartiesPartyChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/alessiodp_parties/AlessiodpPartiesPartyChannel.java
@@ -36,14 +36,13 @@ import net.draycia.carbon.common.messages.CarbonMessages;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class AlessiodpPartiesPartyChannel extends ConfigChatChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/dsrv/DSRVListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/dsrv/DSRVListener.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public final class DSRVListener implements ChatHook {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/essxd/EssXDListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/essxd/EssXDListener.java
@@ -32,7 +32,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public final class EssXDListener implements Listener {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AbstractFactionsChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AbstractFactionsChannel.java
@@ -26,11 +26,10 @@ import com.massivecraft.factions.perms.Relation;
 import com.massivecraft.factions.perms.Role;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.channels.ConfigChatChannel;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 abstract class AbstractFactionsChannel extends ConfigChatChannel {
 
     protected final @Nullable Faction faction(final CarbonPlayer player) {

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AllianceChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/AllianceChannel.java
@@ -36,14 +36,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class AllianceChannel extends AbstractFactionsChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionChannel.java
@@ -33,14 +33,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class FactionChannel extends AbstractFactionsChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionModChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionModChannel.java
@@ -35,14 +35,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class FactionModChannel extends AbstractFactionsChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionsIntegration.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/FactionsIntegration.java
@@ -24,11 +24,10 @@ import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
 import org.bukkit.Bukkit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class FactionsIntegration implements Integration {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/TruceChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/fuuid/TruceChannel.java
@@ -37,14 +37,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class TruceChannel extends AbstractFactionsChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoIntegration.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoIntegration.java
@@ -25,12 +25,11 @@ import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class McmmoIntegration implements Integration {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/mcmmo/McmmoPartyChannel.java
@@ -36,14 +36,13 @@ import net.kyori.adventure.key.Key;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 public class McmmoPartyChannel extends ConfigChatChannel {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/plotsquared/PlotChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/plotsquared/PlotChannel.java
@@ -37,14 +37,13 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 @ConfigHeader(PlotChannel.PLOT_CHANNEL_HEADER)
 public class PlotChannel extends ConfigChatChannel {

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/plotsquared/PlotSquaredIntegration.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/plotsquared/PlotSquaredIntegration.java
@@ -24,11 +24,10 @@ import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
 import org.bukkit.Bukkit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PlotSquaredIntegration implements Integration {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/AllianceChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/AllianceChannel.java
@@ -28,11 +28,10 @@ import net.draycia.carbon.common.config.ConfigHeader;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 @ConfigHeader(ResidentListChannel.TOWNY_CHANNEL_HEADER)
 public class AllianceChannel extends NationChannel {

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/NationChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/NationChannel.java
@@ -28,12 +28,11 @@ import net.draycia.carbon.common.channels.messages.ConfigChannelMessageSource;
 import net.draycia.carbon.common.config.ConfigHeader;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 @ConfigHeader(ResidentListChannel.TOWNY_CHANNEL_HEADER)
 public class NationChannel extends ResidentListChannel<Nation> {

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/ResidentListChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/ResidentListChannel.java
@@ -33,13 +33,12 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.draycia.carbon.api.channels.ChannelPermissionResult.channelPermissionResult;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 abstract class ResidentListChannel<T extends ResidentList> extends ConfigChatChannel {
 
     protected static final String TOWNY_CHANNEL_HEADER = """

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/TownChannel.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/TownChannel.java
@@ -28,12 +28,11 @@ import net.draycia.carbon.common.channels.messages.ConfigChannelMessageSource;
 import net.draycia.carbon.common.config.ConfigHeader;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @ConfigSerializable
 @ConfigHeader(ResidentListChannel.TOWNY_CHANNEL_HEADER)
 public class TownChannel extends ResidentListChannel<Town> {

--- a/paper/src/main/java/net/draycia/carbon/paper/integration/towny/TownyIntegration.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/integration/towny/TownyIntegration.java
@@ -24,11 +24,10 @@ import net.draycia.carbon.common.channels.CarbonChannelRegistry;
 import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.integration.Integration;
 import org.bukkit.Bukkit;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class TownyIntegration implements Integration {
 
     private final CarbonChannelRegistry channelRegistry;

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperChatListener.java
@@ -36,11 +36,11 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PaperChatListener extends ChatListenerInternal implements Listener {
 
     private final CarbonChat carbonChat;

--- a/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperPlayerJoinListener.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/listeners/PaperPlayerJoinListener.java
@@ -34,14 +34,13 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.draycia.carbon.common.users.PlayerUtils.joinExceptionHandler;
 import static net.draycia.carbon.common.users.PlayerUtils.saveExceptionHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class PaperPlayerJoinListener implements Listener {
 
     private final ConfigManager configManager;

--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PaperMessageRenderer.java
@@ -40,13 +40,12 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public class PaperMessageRenderer extends CarbonMessageRenderer {
 

--- a/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/messages/PlaceholderAPIMiniMessageParser.java
@@ -32,11 +32,10 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PlaceholderAPIMiniMessageParser {
 
     private final MiniMessage miniMessage;

--- a/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/CarbonPlayerPaper.java
@@ -42,12 +42,11 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemRarity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements ForwardingAudience.Single {
 
     @AssistedInject
@@ -72,7 +71,7 @@ public final class CarbonPlayerPaper extends WrappedCarbonPlayer implements Forw
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.player().map(player -> (Audience) player).orElseGet(() -> EmptyAudienceWithPointers.forCarbonPlayer(this));
     }
 

--- a/paper/src/main/java/net/draycia/carbon/paper/users/PaperProfileResolver.java
+++ b/paper/src/main/java/net/draycia/carbon/paper/users/PaperProfileResolver.java
@@ -27,12 +27,11 @@ import net.draycia.carbon.common.users.MojangProfileResolver;
 import net.draycia.carbon.common.users.ProfileResolver;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class PaperProfileResolver implements ProfileResolver {
 
     private final Server server;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/CarbonChatSponge.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/CarbonChatSponge.java
@@ -49,9 +49,9 @@ import net.kyori.moonshine.message.IMessageRenderer;
 import ninja.egg82.messenger.services.PacketService;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Server;
 import org.spongepowered.api.Sponge;
@@ -66,7 +66,7 @@ import org.spongepowered.plugin.PluginContainer;
 import org.spongepowered.plugin.builtin.jvm.Plugin;
 
 @Plugin("carbonchat")
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatSponge implements CarbonChat {
 
     private static final Set<Class<?>> LISTENER_CLASSES = Set.of(SpongeChatListener.class,

--- a/sponge/src/main/java/net/draycia/carbon/sponge/CarbonChatSpongeModule.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/CarbonChatSpongeModule.java
@@ -19,10 +19,6 @@
  */
 package net.draycia.carbon.sponge;
 
-import org.incendo.cloud.CommandManager;
-import org.incendo.cloud.execution.AsynchronousCommandExecutionCoordinator;
-import org.incendo.cloud.sponge.SpongeCommandManager;
-import org.incendo.cloud.sponge.argument.SinglePlayerSelectorArgument;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
@@ -42,12 +38,15 @@ import net.draycia.carbon.sponge.command.SpongePlayerCommander;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.moonshine.message.IMessageRenderer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.execution.AsynchronousCommandExecutionCoordinator;
+import org.incendo.cloud.sponge.SpongeCommandManager;
+import org.incendo.cloud.sponge.argument.SinglePlayerSelectorArgument;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.plugin.PluginContainer;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatSpongeModule extends AbstractModule {
 
     private final CarbonChatSponge carbonChat;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/CarbonServerSponge.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/CarbonServerSponge.java
@@ -32,16 +32,15 @@ import net.draycia.carbon.common.users.CarbonPlayerCommon;
 import net.draycia.carbon.sponge.users.CarbonPlayerSponge;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.profile.ProfileNotFoundException;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonServerSponge implements CarbonServer, ForwardingAudience.Single {
 
     private final Game game;
@@ -54,7 +53,7 @@ public final class CarbonServerSponge implements CarbonServer, ForwardingAudienc
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.game.server();
     }
 

--- a/sponge/src/main/java/net/draycia/carbon/sponge/SpongeMessageRenderer.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/SpongeMessageRenderer.java
@@ -33,11 +33,9 @@ import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.moonshine.message.IMessageRenderer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class SpongeMessageRenderer<T extends Audience> implements IMessageRenderer<T, String, Component, Component> {
 
     private final ConfigFactory configFactory;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/SpongeUserManager.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/SpongeUserManager.java
@@ -28,11 +28,10 @@ import net.draycia.carbon.common.users.SaveOnChange;
 import net.draycia.carbon.sponge.users.CarbonPlayerSponge;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class SpongeUserManager implements UserManager<CarbonPlayerSponge>, SaveOnChange {
 
     protected final UserManager<CarbonPlayerCommon> proxiedUserManager;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/command/SpongeCommander.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/command/SpongeCommander.java
@@ -22,12 +22,11 @@ package net.draycia.carbon.sponge.command;
 import net.draycia.carbon.common.command.Commander;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.api.command.CommandCause;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface SpongeCommander extends Commander, ForwardingAudience.Single {
 
     static SpongeCommander from(final CommandCause commandCause) {
@@ -39,7 +38,7 @@ public interface SpongeCommander extends Commander, ForwardingAudience.Single {
     record SpongeCommanderImpl(CommandCause commandCause) implements SpongeCommander {
 
         @Override
-        public @NotNull Audience audience() {
+        public @NonNull Audience audience() {
             return this.commandCause.audience();
         }
 

--- a/sponge/src/main/java/net/draycia/carbon/sponge/command/SpongePlayerCommander.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/command/SpongePlayerCommander.java
@@ -23,15 +23,14 @@ import net.draycia.carbon.api.CarbonChat;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.kyori.adventure.audience.Audience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.api.command.CommandCause;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record SpongePlayerCommander(
     CarbonChat carbon,
     ServerPlayer player,
@@ -44,7 +43,7 @@ public record SpongePlayerCommander(
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.commandCause.audience();
     }
 

--- a/sponge/src/main/java/net/draycia/carbon/sponge/listeners/SpongeChatListener.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/listeners/SpongeChatListener.java
@@ -29,8 +29,8 @@ import net.draycia.carbon.api.channels.ChannelRegistry;
 import net.draycia.carbon.api.events.CarbonChatEvent;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.ComponentPlayerResult;
-import net.draycia.carbon.api.util.KeyedRenderer;
 import net.draycia.carbon.api.util.Component;
+import net.draycia.carbon.api.util.KeyedRenderer;
 import net.draycia.carbon.sponge.CarbonChatSponge;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
@@ -40,9 +40,8 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 import org.spongepowered.api.event.Listener;
@@ -57,7 +56,7 @@ import static net.kyori.adventure.key.Key.key;
 import static net.kyori.adventure.text.Component.empty;
 import static net.kyori.adventure.text.Component.text;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class SpongeChatListener {
 
     private final CarbonChatSponge carbonChat;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/listeners/SpongePlayerJoinListener.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/listeners/SpongePlayerJoinListener.java
@@ -25,12 +25,11 @@ import net.draycia.carbon.api.users.UserManager;
 import net.draycia.carbon.common.users.CarbonPlayerCommon;
 import net.draycia.carbon.common.util.PlayerUtils;
 import net.draycia.carbon.sponge.users.CarbonPlayerSponge;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.network.ServerSideConnectionEvent;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class SpongePlayerJoinListener {
 
     private final CarbonChat carbonChat;

--- a/sponge/src/main/java/net/draycia/carbon/sponge/users/CarbonPlayerSponge.java
+++ b/sponge/src/main/java/net/draycia/carbon/sponge/users/CarbonPlayerSponge.java
@@ -28,10 +28,9 @@ import net.draycia.carbon.common.users.WrappedCarbonPlayer;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.Keys;
 import org.spongepowered.api.entity.living.player.server.ServerPlayer;
@@ -44,7 +43,7 @@ import org.spongepowered.api.util.locale.LocaleSource;
 import static net.kyori.adventure.text.Component.translatable;
 import static net.kyori.adventure.text.format.TextDecoration.ITALIC;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonPlayerSponge extends WrappedCarbonPlayer implements ForwardingAudience.Single {
 
     private final CarbonPlayerCommon carbonPlayerCommon;
@@ -54,7 +53,7 @@ public final class CarbonPlayerSponge extends WrappedCarbonPlayer implements For
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.player()
             .map(player -> (Audience) player)
             .orElseGet(Audience::empty);

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
   alias(libs.plugins.resource.factory.velocity.convention)
 }
 
+indra {
+  javaVersions {
+    target(25)
+  }
+}
+
 val bstats: Configuration by configurations.creating
 configurations.compileOnly {
   extendsFrom(bstats)
@@ -87,8 +93,4 @@ publishMods.modrinth {
   optional {
     slug = "signedvelocity"
   }
-}
-
-configurations.runtimeDownload {
-  exclude("org.checkerframework", "checker-qual")
 }

--- a/velocity/src/main/java/net/draycia/carbon/velocity/CarbonChatVelocity.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/CarbonChatVelocity.java
@@ -42,10 +42,9 @@ import net.draycia.carbon.common.users.ProfileCache;
 import net.draycia.carbon.common.users.ProfileResolver;
 import net.draycia.carbon.velocity.listeners.VelocityListener;
 import org.apache.logging.log4j.LogManager;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public class CarbonChatVelocity extends CarbonChatInternal {
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/CarbonChatVelocityModule.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/CarbonChatVelocityModule.java
@@ -54,13 +54,12 @@ import net.draycia.carbon.velocity.users.VelocityProfileResolver;
 import net.kyori.adventure.key.Key;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.SenderMapper;
 import org.incendo.cloud.velocity.VelocityCommandManager;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonChatVelocityModule extends CarbonPlatformModule {
 
     private final Logger logger = LogManager.getLogger("carbonchat");

--- a/velocity/src/main/java/net/draycia/carbon/velocity/CarbonServerVelocity.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/CarbonServerVelocity.java
@@ -30,11 +30,10 @@ import net.draycia.carbon.common.users.ConsoleCarbonPlayer;
 import net.draycia.carbon.common.users.UserManagerInternal;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonServerVelocity implements CarbonServer, ForwardingAudience.Single {
 
     private final ProxyServer server;
@@ -47,7 +46,7 @@ public final class CarbonServerVelocity implements CarbonServer, ForwardingAudie
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.server;
     }
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/VelocityMessageRenderer.java
@@ -34,11 +34,10 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 @Singleton
 public class VelocityMessageRenderer extends CarbonMessageRenderer {
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/command/VelocityCommander.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/command/VelocityCommander.java
@@ -23,11 +23,10 @@ import com.velocitypowered.api.command.CommandSource;
 import net.draycia.carbon.common.command.Commander;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public interface VelocityCommander extends Commander, ForwardingAudience.Single {
 
     static VelocityCommander from(final CommandSource source) {
@@ -39,7 +38,7 @@ public interface VelocityCommander extends Commander, ForwardingAudience.Single 
     record VelocityCommanderImpl(CommandSource commandSource) implements VelocityCommander {
 
         @Override
-        public @NotNull Audience audience() {
+        public @NonNull Audience audience() {
             return this.commandSource;
         }
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/command/VelocityPlayerCommander.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/command/VelocityPlayerCommander.java
@@ -25,13 +25,12 @@ import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.api.users.UserManager;
 import net.draycia.carbon.common.command.PlayerCommander;
 import net.kyori.adventure.audience.Audience;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import static java.util.Objects.requireNonNull;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public record VelocityPlayerCommander(
     UserManager<?> userManager,
     Player player
@@ -43,7 +42,7 @@ public record VelocityPlayerCommander(
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.player;
     }
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityChatListener.java
@@ -42,11 +42,10 @@ import net.draycia.carbon.velocity.CarbonVelocityBootstrap;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class VelocityChatListener extends ChatListenerInternal implements VelocityListener<PlayerChatEvent> {
 
     private final UserManager<?> userManager;

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityPlayerJoinListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityPlayerJoinListener.java
@@ -28,13 +28,12 @@ import net.draycia.carbon.common.config.ConfigManager;
 import net.draycia.carbon.common.users.UserManagerInternal;
 import net.draycia.carbon.velocity.CarbonVelocityBootstrap;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import static net.draycia.carbon.common.users.PlayerUtils.joinExceptionHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class VelocityPlayerJoinListener implements VelocityListener<LoginEvent> {
 
     private final ConfigManager configManager;

--- a/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityPlayerLeaveListener.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/listeners/VelocityPlayerLeaveListener.java
@@ -26,12 +26,11 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import net.draycia.carbon.common.users.UserManagerInternal;
 import net.draycia.carbon.velocity.CarbonVelocityBootstrap;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
 
 import static net.draycia.carbon.common.users.PlayerUtils.saveExceptionHandler;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class VelocityPlayerLeaveListener implements VelocityListener<DisconnectEvent> {
 
     private final UserManagerInternal<?> userManager;

--- a/velocity/src/main/java/net/draycia/carbon/velocity/users/CarbonPlayerVelocity.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/users/CarbonPlayerVelocity.java
@@ -34,12 +34,11 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public final class CarbonPlayerVelocity extends WrappedCarbonPlayer implements ForwardingAudience.Single {
 
     private final ProxyServer server;
@@ -51,7 +50,7 @@ public final class CarbonPlayerVelocity extends WrappedCarbonPlayer implements F
     }
 
     @Override
-    public @NotNull Audience audience() {
+    public @NonNull Audience audience() {
         return this.player().map(value -> (Audience) value).orElseGet(() -> EmptyAudienceWithPointers.forCarbonPlayer(this));
     }
 

--- a/velocity/src/main/java/net/draycia/carbon/velocity/users/VelocityProfileResolver.java
+++ b/velocity/src/main/java/net/draycia/carbon/velocity/users/VelocityProfileResolver.java
@@ -26,12 +26,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import net.draycia.carbon.common.users.MojangProfileResolver;
 import net.draycia.carbon.common.users.ProfileResolver;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultQualifier;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @Singleton
-@DefaultQualifier(NonNull.class)
+@NullMarked
 public class VelocityProfileResolver implements ProfileResolver {
 
     private final ProxyServer proxyServer;


### PR DESCRIPTION
## Summary
- Migrate nullness annotations from Checker Framework to JSpecify.
- Update Velocity support to 4.0 / Java 25.
- Restore the nullable default method now that runtime JSpecify support is expected.

## Blocked by
This PR is blocked on https://github.com/PaperMC/Velocity/pull/1861, which adds JSpecify to Velocity’s runtime classpath.