### PR TITLE
🐛 Fix leave permission check

### DIFF
--- a/common/src/main/java/net/draycia/carbon/common/command/commands/JoinCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/JoinCommand.java
@@ -77,9 +77,7 @@ public final class JoinCommand extends CarbonCommand {
                 return sender.leftChannels().stream()
                     .map(this.channelRegistry::channel)
                     .filter(Objects::nonNull)
-                    .filter(channel -> channel.permissions().joinPermitted(sender).permitted()
-                        || channel.permissions().hearingPermitted(sender).permitted()
-                        || channel.permissions().speechPermitted(sender).permitted())
+                    .filter(channel -> channel.permissions().joinPermitted(sender).permitted())
                     .map(channel -> channel.key().value())
                     .map(Suggestion::suggestion)
                     .toList();

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
@@ -21,6 +21,7 @@ package net.draycia.carbon.common.command.commands;
 
 import com.google.inject.Inject;
 import java.util.Objects;
+import net.draycia.carbon.api.channels.ChannelPermissionResult;
 import net.draycia.carbon.api.channels.ChatChannel;
 import net.draycia.carbon.api.users.CarbonPlayer;
 import net.draycia.carbon.common.channels.CarbonChannelRegistry;
@@ -94,6 +95,11 @@ public final class LeaveCommand extends CarbonCommand {
                 }
                 if (sender.leftChannels().contains(channel.key())) {
                     this.carbonMessages.channelAlreadyLeft(sender);
+                    return;
+                }
+                final ChannelPermissionResult permitted = channel.permissions().joinPermitted(sender);
+                if (!permitted.permitted()) {
+                    sender.sendMessage(permitted.reason());
                     return;
                 }
                 sender.leaveChannel(channel);

--- a/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
+++ b/common/src/main/java/net/draycia/carbon/common/command/commands/LeaveCommand.java
@@ -78,7 +78,7 @@ public final class LeaveCommand extends CarbonCommand {
                     .map(this.channelRegistry::channel)
                     .filter(Objects::nonNull)
                     .filter(x -> !sender.leftChannels().contains(x.key())
-                        && (x.permissions().joinPermitted(sender).permitted() || x.permissions().hearingPermitted(sender).permitted() || x.permissions().speechPermitted(sender).permitted()))
+                        && (x.permissions().joinPermitted(sender).permitted()))
                     .map(x -> x.key().value())
                     .map(Suggestion::suggestion)
                     .toList();


### PR DESCRIPTION
This checks the carbon.channel.<channelname> permission also when you leave a channel. Otherwise, you can just leave your broadcast channel which doesn't really make sense.

It also makes that the suggestion for leave & join only suggest channels with this permission.